### PR TITLE
Define M79 grenade launcher bulk to be -4.

### DIFF
--- a/Library/Equipment/High Tech.eqp
+++ b/Library/Equipment/High Tech.eqp
@@ -10384,6 +10384,7 @@
 			<range>30/440</range>
 			<rate_of_fire>1</rate_of_fire>
 			<shots>1(3)</shots>
+			<bulk>-4</bulk>
 			<recoil>2</recoil>
 			<default>
 				<type>Skill</type>


### PR DESCRIPTION
Was undefined before.