### PR TITLE
Added NPC card template for HTML output

### DIFF
--- a/Library/Output Templates/npc_card_template.html
+++ b/Library/Output Templates/npc_card_template.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<!--
+  NPC Record Card template by Steve Jackson Games.
+  Implemented by Pizza for use with Richard A. Wilkes' GCS.
+-->
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <title>NPC Card</title>
+    <style>
+      body {
+        font-size: 9pt;
+      }
+      #border {
+        width: 5in;
+        height: 3in;
+        border-style: solid;
+        border-width: 2px;
+        margin: 0.05in;
+        text-overflow: ellipsis;
+        overflow-y: hidden;
+      }
+      #basic_damage_title{
+        text-align: center;
+        width: inherit;
+      }
+      .name, .appearance, .will_per, .speed_move, .encumbrance, .defenses, .reaction_points, .advantages, .skills, .weapons, .basic_attributes tr, .name_row{
+        padding-bottom: 0.05in;
+      }
+      .weapon{
+        padding-top:0.05in;
+      }
+      .b_att{
+        padding-right: 0.07in;
+        font-weight: bold;
+      }
+      .slanted{
+        transform: rotate(-75deg);
+      }
+      .dr table{
+        table-layout: fixed;
+        width: 100% ;
+      }
+      .dr_value{
+        border-style: solid;
+        border-width: 1px;
+        text-align: center;
+        vertical-align: middle;
+        height: 0.19in;
+      }
+      .smaller{
+        font-size: 7pt;
+        line-height: 1.0;
+      }
+      .enc_remove, .Eye, .Face, .Vitals, .Groin, .Right, .Neck{
+        display: none;
+      }
+      .slanted.Left.Leg span, .slanted.Left.Arm span, .slanted.Hand span, .slanted.Skull span, .slanted.Foot span{
+        display: none;
+      }
+      .slanted.Skull::after{
+        content: "Head";
+      }
+      .slanted.Left.Leg::after{
+        content: "Legs";
+      }
+      .slanted.Left.Arm::after{
+        content: "Arms";
+      }
+      .slanted.Hand::after{
+        content: "Hands";
+      }
+      .slanted.Foot::after{
+        content: "Feet";
+      }
+      .slanted{
+        width: 13%;
+      }
+      .current{
+        display: inline;
+      }
+      .name_row {
+        height: 0.2in;
+      }
+      .lift_sm{
+        padding-bottom: 0.1in;
+      }
+      #left_column{
+        width: 1.8in;
+        vertical-align: text-top;
+      }
+      #right_column{
+        vertical-align: text-top;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="border">
+      <table id="contents">
+        <tr>
+          <td id="left_column">
+            <div class="name">
+              <b>@NAME</b>
+            </div>
+            <div class="appearance smaller">
+              Skin: @SKIN; Eyes: @EYES; Hair: @HAIR
+            </div>
+            <table class="basic_attributes">
+              <tr>
+                <td><b>@ST</b></td>
+                <td class="b_att">ST</td>
+                <td>HP: <b>@BASIC_HP</b> ______</td>
+              </tr>
+              <tr>
+                <td><b>@DX</b></td>
+                <td class="b_att">DX</td>
+                <td><i>Thrust</i>: @THRUST</td>
+              </tr>
+              <tr>
+                <td><b>@IQ</b></td>
+                <td class="b_att">IQ</td>
+                <td><i>Swing</i>: @SWING</td>
+              </tr>
+              <tr>
+                <td><b>@HT</b></td>
+                <td class="b_att">HT</td>
+                <td>FP: <b>@BASIC_FP</b> ______</td>
+              </tr>
+            </table>
+            <div class="will_per">
+              Will <b>@WILL</b>  Per <b>@PERCEPTION</b>
+            </div>
+            <div class="speed_move">
+              Basic Speed <b>@BASIC_SPEED</b>  Move <b>@BASIC_MOVE</b>
+            </div>
+
+            <div class="encumbrance">
+              Encumbrance <b>@ENCUMBRANCE_LOOP_START<span class="enc_remove @CURRENT_MARKER">@LEVEL</span>@ENCUMBRANCE_LOOP_END</b>
+            </div>
+
+            <div class="defenses">
+              Dodge <b>@CURRENT_DODGE</b>  Parry <b>@BEST_CURRENT_PARRY</b>  Block <b>@BEST_CURRENT_BLOCK</b>
+            </div>
+            <div class="lift_sm">
+              Basic Lift <b>@BASIC_LIFT</b> SM <b>@SIZE</b>
+            </div>
+
+            <div class="dr">
+              <table>
+                <tr class="name_row">
+                  <td></td>
+                  @HIT_LOCATION_LOOP_START
+                  <td class="slanted smaller @WHERE"><span>@WHERE</span></td>
+                  @HIT_LOCATION_LOOP_END
+                </tr>
+                <tr>
+                  <td>DR</td>
+                  @HIT_LOCATION_LOOP_START
+                  <td class="dr_value @WHERE">@DR</td>
+                  @HIT_LOCATION_LOOP_END
+                </tr>
+              </table>
+            </div>
+
+
+          </td>
+          <td id="right_column">
+            <div class="reaction_points">
+              Reaction +/- _________ Point Total <b>@TOTAL_POINTS</b>
+            </div>
+            <div class="advantages">
+              Advantages, Disadvantages, Quirks: <span class="smaller">@ADVANTAGES_LOOP_START@DESCRIPTION_PRIMARY, @ADVANTAGES_LOOP_END</span>
+            </div>
+            <div class="skills">
+              Skills: <span class="smaller">@SKILLS_LOOP_START@DESCRIPTION_PRIMARY-<b>@SL</b>, @SKILLS_LOOP_END@SPELLS_LOOP_START@DESCRIPTION_PRIMARY-<b>@SL</b>, @SPELLS_LOOP_END</span>
+
+            </div>
+            <div class="weapons">
+              Weapon Statistics:
+              @MELEE_LOOP_START<div class="smaller weapon">@DESCRIPTION_PRIMARY <i>@USAGE</i>: <b>@DAMAGE</b></div>@MELEE_LOOP_END
+              @RANGED_LOOP_START
+              <div class="smaller weapon">
+                @DESCRIPTION_PRIMARY <i>@USAGE</i>: <b>@DAMAGE</b>, Acc <b>@ACCURACY</b>, Range <b>@RANGE</b>, Bulk <b>@BULK</b>, Rcl <b>@RECOIL</b>
+              </div>
+              @RANGED_LOOP_END
+            </div>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
I have added a HTML output template that matches the [GURPS NPC record card](www.sjgames.com/gurps/resources/NPCandTimeUse.pdf) format to the extent of my CSS skills.
This allows outputting in a very simple format with a fixed size (3in x 5in). 

Cards include most basic and derived attributes, DR of important hit locations, advantages/disadvantages, skills/spells and weapon stats.