### PR TITLE
Add Elven Gear advantage to Dungeon Fantasy RPG Advantages

### DIFF
--- a/Library/Advantages/Dungeon Fantasy RPG.adq
+++ b/Library/Advantages/Dungeon Fantasy RPG.adq
@@ -4052,7 +4052,7 @@
 		</categories>
 		<spell_bonus>
 			<college_name compare="is">Druid</college_name>
-			<amount>1</amount>
+			<amount per_level="yes">1</amount>
 		</spell_bonus>
 	</advantage>
 	<advantage version="2">

--- a/Library/Advantages/Dungeon Fantasy RPG.adq
+++ b/Library/Advantages/Dungeon Fantasy RPG.adq
@@ -1814,6 +1814,12 @@
 		</categories>
 	</advantage>
 	<advantage version="2">
+		<name>Elven Gear</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>DFA44</reference>
+	</advantage>
+	<advantage version="2">
 		<name>Empathy</name>
 		<type>Mental</type>
 		<base_points>15</base_points>


### PR DESCRIPTION
I found that the Elven Gear advantage from DFA44, under the Special Elf Traits, was missing.  I looked at how Dwarven Gear was specified and did the same thing for Elven Gear.