### PR TITLE
Remove Breath Control and Meditation prerequisites from DFRPG skill Body Control.

### DIFF
--- a/Library/Advantages/Dungeon Fantasy RPG.adq
+++ b/Library/Advantages/Dungeon Fantasy RPG.adq
@@ -2295,12 +2295,6 @@
 			<specialization compare="is">woodlands</specialization>
 			<amount per_level="yes">1</amount>
 		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="ends with">Elf</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
 	</advantage>
 	<advantage version="2">
 		<name>Frightens Animals</name>

--- a/Library/Advantages/Dungeon Fantasy RPG.adq
+++ b/Library/Advantages/Dungeon Fantasy RPG.adq
@@ -4052,7 +4052,7 @@
 		</categories>
 		<spell_bonus>
 			<college_name compare="is">Druid</college_name>
-			<amount>1</amount>
+			<amount per_level="yes">1</amount>
 		</spell_bonus>
 	</advantage>
 	<advantage version="2">

--- a/Library/Advantages/Dungeon Fantasy RPG.adq
+++ b/Library/Advantages/Dungeon Fantasy RPG.adq
@@ -1814,6 +1814,12 @@
 		</categories>
 	</advantage>
 	<advantage version="2">
+		<name>Elven Gear</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>DFA44</reference>
+	</advantage>
+	<advantage version="2">
 		<name>Empathy</name>
 		<type>Mental</type>
 		<base_points>15</base_points>

--- a/Library/Skills/Dungeon Fantasy RPG.skl
+++ b/Library/Skills/Dungeon Fantasy RPG.skl
@@ -310,14 +310,6 @@
 			<category>Esoteric</category>
 		</categories>
 		<prereq_list all="yes">
-			<skill_prereq has="yes">
-				<name compare="is">meditation</name>
-				<specialization compare="is anything"></specialization>
-			</skill_prereq>
-			<skill_prereq has="yes">
-				<name compare="is">breath control</name>
-				<specialization compare="is anything"></specialization>
-			</skill_prereq>
 			<advantage_prereq has="yes">
 				<name compare="is">trained by a master</name>
 				<notes compare="is anything"></notes>


### PR DESCRIPTION
Unlike the Body Control Skill from GURPS Basic Set, the DFRPG skill Body Control doesn't have those as prerequisites.