### PR TITLE
Adds Modifiers & Advantages from GURPS Psionic Powers

### DIFF
--- a/Library/Basic Set/Basic Set Advantages.adq
+++ b/Library/Basic Set/Basic Set Advantages.adq
@@ -464,6 +464,12 @@
 			<cost type="percentage">400</cost>
 			<affects>total</affects>
 		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Cancellation</name>
+			<reference>PSI13</reference>
+			<cost type="percentage">10</cost>
+			<affects>total</affects>
+		</modifier>
 		<reference>B35</reference>
 		<categories>
 			<category>Advantage</category>
@@ -738,6 +744,66 @@
 			<affects>total</affects>
 		</modifier>
 		<reference>B38</reference>
+		<categories>
+			<category>Advantage</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Alternate Form</name>
+		<type>Physical, Exotic</type>
+		<base_points>15</base_points>
+		<modifier version="1" enabled="no">
+			<name>Cosmetic</name>
+			<reference>B84</reference>
+			<cost type="percentage">-50</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Absorptive Change</name>
+			<reference>P75</reference>
+			<cost type="percentage">5</cost>
+			<levels>1</levels>
+			<affects>total</affects>
+			<notes>@Level of Absorptive Change. 1 None, 2, Light, 3, Medium, 4, Heavy, 5, Extra Heavy@</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Active Change</name>
+			<reference>P75</reference>
+			<cost type="percentage">20</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Non-Reciprocal Damage</name>
+			<reference>P75</reference>
+			<cost type="percentage">50</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Once On, Stays On</name>
+			<reference>P75</reference>
+			<cost type="percentage">50</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Reciprocal Rest</name>
+			<reference>P75</reference>
+			<cost type="percentage">30</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Projected Form</name>
+			<reference>P75</reference>
+			<cost type="percentage">-50</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Takes Extra Time</name>
+			<reference>B115</reference>
+			<cost type="percentage">-10</cost>
+			<levels>1</levels>
+			<affects>total</affects>
+		</modifier>
+		<reference>B83</reference>
 		<categories>
 			<category>Advantage</category>
 		</categories>
@@ -1688,6 +1754,18 @@
 			<cost type="percentage">70</cost>
 			<affects>total</affects>
 		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Fixed Range</name>
+			<reference>PSI13</reference>
+			<cost type="percentage">-5</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Normal Sight</name>
+			<reference>PSI13</reference>
+			<cost type="percentage">-20</cost>
+			<affects>total</affects>
+		</modifier>
 		<reference>B42</reference>
 		<categories>
 			<category>Advantage</category>
@@ -2392,6 +2470,38 @@
 			<cost type="points">-40</cost>
 			<affects>base only</affects>
 		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Limited, One Ability</name>
+			<reference>PSI13</reference>
+			<cost type="percentage">-30</cost>
+			<affects>total</affects>
+			<notes>@Ability@</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Limited, One Power</name>
+			<reference>PSI13</reference>
+			<cost type="percentage">-20</cost>
+			<affects>total</affects>
+			<notes>@Power@</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Mental Separation Only</name>
+			<reference>PSI13</reference>
+			<cost type="percentage">-80</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Mentalism</name>
+			<reference>PSI14</reference>
+			<cost type="percentage">-10</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>No Mental Separation</name>
+			<reference>PSI14</reference>
+			<cost type="percentage">-20</cost>
+			<affects>total</affects>
+		</modifier>
 		<reference>B43</reference>
 		<categories>
 			<category>Advantage</category>
@@ -2814,6 +2924,18 @@
 			<name>Laminate</name>
 			<reference>RSWL18</reference>
 			<cost type="percentage">10</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Malediction-Proof</name>
+			<reference>PSI14</reference>
+			<cost type="percentage">50</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Maledictions Only</name>
+			<reference>PSI14</reference>
+			<cost type="percentage">0</cost>
 			<affects>total</affects>
 		</modifier>
 		<reference>B47</reference>
@@ -3342,6 +3464,30 @@
 			<name>Analyzing</name>
 			<reference>P47</reference>
 			<cost type="percentage">100</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Lock-On</name>
+			<reference>PSI14</reference>
+			<cost type="percentage">50</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Precise, Nontargeting</name>
+			<reference>PSI14</reference>
+			<cost type="percentage">90</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Analysis Only</name>
+			<reference>PSI14</reference>
+			<cost type="percentage">-50</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Cannoy Analyze</name>
+			<reference>PSI14</reference>
+			<cost type="percentage">-10</cost>
 			<affects>total</affects>
 		</modifier>
 		<reference>B48</reference>
@@ -5094,6 +5240,19 @@
 			<cost type="percentage">-20</cost>
 			<affects>total</affects>
 		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Slow</name>
+			<reference>PSI14</reference>
+			<cost type="percentage">-25</cost>
+			<affects>total</affects>
+			<notes>Basic Speed</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Slow, Move 1</name>
+			<reference>PSI14</reference>
+			<cost type="percentage">-45</cost>
+			<affects>total</affects>
+		</modifier>
 		<reference>B56</reference>
 		<categories>
 			<category>Advantage</category>
@@ -5586,6 +5745,12 @@
 			<name>Empathic</name>
 			<reference>P51</reference>
 			<cost type="percentage">-50</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Restore Limbs</name>
+			<reference>PSI14</reference>
+			<cost type="percentage">80</cost>
 			<affects>total</affects>
 		</modifier>
 		<reference>B59</reference>
@@ -6234,34 +6399,6 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Injury Tolerance (Diffuse)</name>
-		<type>Physical, Exotic</type>
-		<base_points>100</base_points>
-		<modifier version="1" enabled="no">
-			<name>Infiltration</name>
-			<reference>P53</reference>
-			<cost type="percentage">40</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Swarm</name>
-			<reference>P53</reference>
-			<cost type="percentage">80</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Swarm</name>
-			<reference>P53</reference>
-			<cost type="percentage">160</cost>
-			<affects>total</affects>
-			<notes>Can Affect Substantial</notes>
-		</modifier>
-		<reference>B60</reference>
-		<categories>
-			<category>Advantage</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
 		<name>Injury Tolerance</name>
 		<type>Physical, Exotic</type>
 		<modifier version="1" enabled="no">
@@ -6308,6 +6445,34 @@
 			<name>No Vitals</name>
 			<cost type="points">5</cost>
 			<affects>total</affects>
+		</modifier>
+		<reference>B60</reference>
+		<categories>
+			<category>Advantage</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Injury Tolerance (Diffuse)</name>
+		<type>Physical, Exotic</type>
+		<base_points>100</base_points>
+		<modifier version="1" enabled="no">
+			<name>Infiltration</name>
+			<reference>P53</reference>
+			<cost type="percentage">40</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Swarm</name>
+			<reference>P53</reference>
+			<cost type="percentage">80</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Swarm</name>
+			<reference>P53</reference>
+			<cost type="percentage">160</cost>
+			<affects>total</affects>
+			<notes>Can Affect Substantial</notes>
 		</modifier>
 		<reference>B60</reference>
 		<categories>
@@ -6543,6 +6708,12 @@
 			<name>No Wounding</name>
 			<reference>B111</reference>
 			<cost type="percentage">-50</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Surge, Arcing</name>
+			<reference>PSI20</reference>
+			<cost type="percentage">100</cost>
 			<affects>total</affects>
 		</modifier>
 		<reference>B61</reference>
@@ -8530,6 +8701,18 @@
 			<cost type="percentage">-35</cost>
 			<affects>total</affects>
 		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Ghost Air</name>
+			<reference>PSI14</reference>
+			<cost type="percentage">10</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Substantial Communication</name>
+			<reference>PSI14</reference>
+			<cost type="percentage">40</cost>
+			<affects>total</affects>
+		</modifier>
 		<reference>B62</reference>
 		<categories>
 			<category>Advantage</category>
@@ -8858,6 +9041,19 @@
 			<affects>total</affects>
 			<notes>@Portal@</notes>
 		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Faster Concentration</name>
+			<reference>PSI15</reference>
+			<cost type="percentage">5</cost>
+			<levels>1</levels>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Improved</name>
+			<reference>PSI15</reference>
+			<cost type="percentage">10</cost>
+			<affects>total</affects>
+		</modifier>
 		<reference>B64</reference>
 		<categories>
 			<category>Advantage</category>
@@ -8975,6 +9171,56 @@
 		<modifier version="1" enabled="no">
 			<name>Native</name>
 			<reference>B23</reference>
+			<cost type="points">-4</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1">
+			<name>Spoken</name>
+			<reference>B24</reference>
+			<cost type="points">1</cost>
+			<affects>total</affects>
+			<notes>Accented</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Spoken</name>
+			<reference>B24</reference>
+			<cost type="points">2</cost>
+			<affects>total</affects>
+			<notes>Native</notes>
+		</modifier>
+		<modifier version="1">
+			<name>Written</name>
+			<reference>B24</reference>
+			<cost type="points">1</cost>
+			<affects>total</affects>
+			<notes>Accented</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Written</name>
+			<reference>B24</reference>
+			<cost type="points">2</cost>
+			<affects>total</affects>
+			<notes>Native</notes>
+		</modifier>
+		<reference>B24</reference>
+		<notes>With Language Talent</notes>
+		<categories>
+			<category>Advantage</category>
+			<category>Language</category>
+		</categories>
+		<prereq_list all="yes">
+			<advantage_prereq has="yes">
+				<name compare="is">Language Talent</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Language: @Language@</name>
+		<type>Mental</type>
+		<modifier version="1" enabled="no">
+			<name>Native</name>
+			<reference>B23</reference>
 			<cost type="points">-6</cost>
 			<affects>total</affects>
 		</modifier>
@@ -9039,56 +9285,6 @@
 			<category>Advantage</category>
 			<category>Language</category>
 		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Language: @Language@</name>
-		<type>Mental</type>
-		<modifier version="1" enabled="no">
-			<name>Native</name>
-			<reference>B23</reference>
-			<cost type="points">-4</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1">
-			<name>Spoken</name>
-			<reference>B24</reference>
-			<cost type="points">1</cost>
-			<affects>total</affects>
-			<notes>Accented</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Spoken</name>
-			<reference>B24</reference>
-			<cost type="points">2</cost>
-			<affects>total</affects>
-			<notes>Native</notes>
-		</modifier>
-		<modifier version="1">
-			<name>Written</name>
-			<reference>B24</reference>
-			<cost type="points">1</cost>
-			<affects>total</affects>
-			<notes>Accented</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Written</name>
-			<reference>B24</reference>
-			<cost type="points">2</cost>
-			<affects>total</affects>
-			<notes>Native</notes>
-		</modifier>
-		<reference>B24</reference>
-		<notes>With Language Talent</notes>
-		<categories>
-			<category>Advantage</category>
-			<category>Language</category>
-		</categories>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="is">Language Talent</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
 	</advantage>
 	<advantage version="3">
 		<name>Laziness</name>
@@ -10043,6 +10239,60 @@
 			<cost type="percentage">-40</cost>
 			<affects>total</affects>
 		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Rationalization</name>
+			<reference>PSI15</reference>
+			<cost type="percentage">20</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Slow and Sure</name>
+			<reference>PSI15</reference>
+			<cost type="percentage">80</cost>
+			<affects>total</affects>
+			<notes>1 hour</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Slow and Sure Only</name>
+			<reference>PSI15</reference>
+			<cost type="percentage">40</cost>
+			<affects>total</affects>
+			<notes>1 hour</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Slow and Sure</name>
+			<reference>PSI15</reference>
+			<cost type="percentage">110</cost>
+			<affects>total</affects>
+			<notes>10 minutes</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Slow and Sure Only</name>
+			<reference>PSI15</reference>
+			<cost type="percentage">70</cost>
+			<affects>total</affects>
+			<notes>10 minutes</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Slow and Sure</name>
+			<reference>PSI15</reference>
+			<cost type="percentage">155</cost>
+			<affects>total</affects>
+			<notes>10 seconds</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Slow and Sure Only</name>
+			<reference>PSI15</reference>
+			<cost type="percentage">115</cost>
+			<affects>total</affects>
+			<notes>10 seconds</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Mind Tricks</name>
+			<reference>PSI15</reference>
+			<cost type="percentage">-30</cost>
+			<affects>total</affects>
+		</modifier>
 		<reference>B68</reference>
 		<categories>
 			<category>Advantage</category>
@@ -10202,6 +10452,49 @@
 			<cost type="percentage">-75</cost>
 			<affects>total</affects>
 			<notes>@Power/College/Focus@</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Lockdown</name>
+			<reference>PSI15</reference>
+			<cost type="percentage">100</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Profiling</name>
+			<reference>PSI15</reference>
+			<cost type="percentage">10</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Reflection</name>
+			<reference>PSI15</reference>
+			<cost type="percentage">100</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Active</name>
+			<reference>PSI15</reference>
+			<cost type="percentage">-25</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Always On</name>
+			<reference>PSI15</reference>
+			<cost type="percentage">-10</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Feedback</name>
+			<reference>PSI15</reference>
+			<cost type="percentage">-25</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Feedback</name>
+			<reference>PSI15</reference>
+			<cost type="percentage">-50</cost>
+			<affects>total</affects>
+			<notes>With Always On</notes>
 		</modifier>
 		<reference>B70</reference>
 		<categories>
@@ -10447,6 +10740,41 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
+		<name>Modular Abilities (Cosmic Power)</name>
+		<type>Physical, Exotic</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1" enabled="no">
+			<name>Physical Only</name>
+			<reference>B71</reference>
+			<cost type="percentage">50</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Physical</name>
+			<reference>B71</reference>
+			<cost type="percentage">100</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Spells Only</name>
+			<reference>B71</reference>
+			<cost type="percentage">-20</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Virtual</name>
+			<reference>B71</reference>
+			<cost type="percentage">-50</cost>
+			<affects>total</affects>
+			<notes>@Realm@</notes>
+		</modifier>
+		<reference>B71</reference>
+		<categories>
+			<category>Advantage</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
 		<name>Modular Abilities (Super-Memorization)</name>
 		<type>Mental, Exotic</type>
 		<levels>1</levels>
@@ -10462,6 +10790,80 @@
 		<categories>
 			<category>Advantage</category>
 		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Morph</name>
+		<type>Physical, Exotic</type>
+		<levels>1</levels>
+		<base_points>100</base_points>
+		<points_per_level>1</points_per_level>
+		<modifier version="1" enabled="no">
+			<name>Unlimited</name>
+			<reference>B85</reference>
+			<cost type="percentage">50</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Cosmetic</name>
+			<reference>B85</reference>
+			<cost type="percentage">-50</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Retains Shape</name>
+			<reference>B85</reference>
+			<cost type="percentage">-20</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Mass Conservation</name>
+			<reference>B85</reference>
+			<cost type="percentage">-20</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Active Change</name>
+			<reference>P75</reference>
+			<cost type="percentage">20</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Improvised Forms</name>
+			<reference>P75</reference>
+			<cost type="percentage">100</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Cosmic (For Improvised Forms)</name>
+			<reference>P75</reference>
+			<cost type="percentage">50</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>No Memorization Required</name>
+			<reference>P75</reference>
+			<cost type="percentage">50</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Cannot Memorize Forms</name>
+			<reference>P75</reference>
+			<cost type="percentage">-50</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Flawed</name>
+			<reference>P75</reference>
+			<cost type="percentage">-10</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Unliving Forms Only</name>
+			<reference>P75</reference>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+		</modifier>
+		<reference>B84</reference>
 	</advantage>
 	<advantage version="3">
 		<name>Motion Sickness</name>
@@ -10883,6 +11285,24 @@
 			<affects>total</affects>
 			<notes>@Ability@ in @Power@</notes>
 		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Derangable</name>
+			<reference>PSI16</reference>
+			<cost type="percentage">10</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Power Theft, Weak</name>
+			<reference>PSI16</reference>
+			<cost type="percentage">100</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Interruption</name>
+			<reference>PSI16</reference>
+			<cost type="percentage">-50</cost>
+			<affects>total</affects>
+		</modifier>
 		<reference>B71</reference>
 		<categories>
 			<category>Advantage</category>
@@ -11279,6 +11699,12 @@
 			<cost type="percentage">-40</cost>
 			<affects>total</affects>
 			<notes>@Power@</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Anti-Targeting</name>
+			<reference>PSI16</reference>
+			<cost type="percentage">-20</cost>
+			<affects>total</affects>
 		</modifier>
 		<reference>B72</reference>
 		<categories>
@@ -12083,6 +12509,28 @@
 			<affects>total</affects>
 			<notes>@Family: Canidae@</notes>
 		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Poor Control</name>
+			<reference>PSI16</reference>
+			<cost type="percentage">-5</cost>
+			<levels>1</levels>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Poor Control</name>
+			<reference>PSI16</reference>
+			<cost type="percentage">-10</cost>
+			<levels>1</levels>
+			<affects>total</affects>
+			<notes>40 Hour Practice</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Poor Control, Permanent</name>
+			<reference>PSI16</reference>
+			<cost type="percentage">-15</cost>
+			<levels>1</levels>
+			<affects>total</affects>
+		</modifier>
 		<reference>B75</reference>
 		<categories>
 			<category>Advantage</category>
@@ -12142,6 +12590,19 @@
 			<reference>P69</reference>
 			<cost type="percentage">-20</cost>
 			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Dreaming</name>
+			<reference>PSI16</reference>
+			<cost type="percentage">-70</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Dreaming</name>
+			<reference>PSI16</reference>
+			<cost type="percentage">-20</cost>
+			<affects>total</affects>
+			<notes>Combined with Active Only or Can't See Own Death</notes>
 		</modifier>
 		<reference>B77</reference>
 		<categories>
@@ -12250,6 +12711,12 @@
 			<name>Passive Only</name>
 			<reference>P69</reference>
 			<cost type="percentage">-60</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Visions</name>
+			<reference>PSI17</reference>
+			<cost type="percentage">50</cost>
 			<affects>total</affects>
 		</modifier>
 		<reference>B78</reference>
@@ -13053,6 +13520,12 @@
 			<cost type="points">10</cost>
 			<affects>total</affects>
 		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Extra-Sensory Awareness</name>
+			<reference>PSI17</reference>
+			<cost type="points">20</cost>
+			<affects>total</affects>
+		</modifier>
 		<reference>B81</reference>
 		<categories>
 			<category>Advantage</category>
@@ -13190,6 +13663,18 @@
 			<name>True Sight</name>
 			<reference>P73</reference>
 			<cost type="percentage">50</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Partially Exclusive</name>
+			<reference>PSI17</reference>
+			<cost type="percentage">-20</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Completely Exclusive</name>
+			<reference>PSI17</reference>
+			<cost type="percentage">-50</cost>
 			<affects>total</affects>
 		</modifier>
 		<reference>B83</reference>
@@ -14710,6 +15195,18 @@
 			<name>Discriminatory</name>
 			<reference>P98</reference>
 			<cost type="percentage">150</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Tiring</name>
+			<reference>PSI17</reference>
+			<cost type="percentage">50</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>One Power</name>
+			<reference>PSI17</reference>
+			<cost type="percentage">-50</cost>
 			<affects>total</affects>
 		</modifier>
 		<reference>B78</reference>
@@ -16642,6 +17139,12 @@
 			<cost type="points">5</cost>
 			<affects>total</affects>
 		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Full Communion</name>
+			<reference>PSI17</reference>
+			<cost type="percentage">20</cost>
+			<affects>total</affects>
+		</modifier>
 		<reference>B91</reference>
 		<categories>
 			<category>Advantage</category>
@@ -16730,6 +17233,18 @@
 			<name>Super-Damage</name>
 			<reference>SU29</reference>
 			<cost type="percentage">900</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Cannot Affect Self</name>
+			<reference>PSI17</reference>
+			<cost type="percentage">-20</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Cannot Punch</name>
+			<reference>PSI17</reference>
+			<cost type="percentage">-10</cost>
 			<affects>total</affects>
 		</modifier>
 		<reference>B92</reference>
@@ -17084,6 +17599,30 @@
 			<name>IQ Only</name>
 			<reference>RSWL24</reference>
 			<cost type="percentage">-75</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Halt Aging, Weekly</name>
+			<reference>PSI18</reference>
+			<cost type="percentage">80</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Halt Aging, Monthly</name>
+			<reference>PSI18</reference>
+			<cost type="percentage">100</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Halt Aging, Yearly</name>
+			<reference>PSI18</reference>
+			<cost type="percentage">130</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Life Extension</name>
+			<reference>PSI18</reference>
+			<cost type="percentage">-30</cost>
 			<affects>total</affects>
 		</modifier>
 		<reference>B95</reference>
@@ -17903,6 +18442,18 @@
 			<cost type="percentage">-50</cost>
 			<affects>total</affects>
 		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Gyroscopic</name>
+			<reference>PSI18</reference>
+			<cost type="percentage">10</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Blink Only</name>
+			<reference>PSI18</reference>
+			<cost type="percentage">-60</cost>
+			<affects>total</affects>
+		</modifier>
 		<reference>B97</reference>
 		<categories>
 			<category>Advantage</category>
@@ -18205,138 +18756,5 @@
 		<categories>
 			<category>Advantage</category>
 		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Alternate Form</name>
-		<type>Physical, Exotic</type>
-		<base_points>15</base_points>
-		<modifier version="1" enabled="no">
-			<name>Cosmetic</name>
-			<reference>B84</reference>
-			<cost type="percentage">-50</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Absorptive Change</name>
-			<reference>P75</reference>
-			<cost type="percentage">5</cost>
-			<levels>1</levels>
-			<affects>total</affects>
-			<notes>@Level of Absorptive Change. 1 None, 2, Light, 3, Medium, 4, Heavy, 5, Extra Heavy@</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Active Change</name>
-			<reference>P75</reference>
-			<cost type="percentage">20</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Non-Reciprocal Damage</name>
-			<reference>P75</reference>
-			<cost type="percentage">50</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Once On, Stays On</name>
-			<reference>P75</reference>
-			<cost type="percentage">50</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Reciprocal Rest</name>
-			<reference>P75</reference>
-			<cost type="percentage">30</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Projected Form</name>
-			<reference>P75</reference>
-			<cost type="percentage">-50</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Takes Extra Time</name>
-			<cost type="percentage">-10</cost>
-			<levels>1</levels>
-			<affects>total</affects>
-		</modifier>
-		<reference>B83</reference>
-		<categories>
-			<category>Advantage</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Morph</name>
-		<type>Physical, Exotic</type>
-		<levels>1</levels>
-		<base_points>100</base_points>
-		<points_per_level>1</points_per_level>
-		<modifier version="1" enabled="no">
-			<name>Unlimited</name>
-			<reference>B85</reference>
-			<cost type="percentage">50</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Cosmetic</name>
-			<reference>B85</reference>
-			<cost type="percentage">-50</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Retains Shape</name>
-			<reference>B85</reference>
-			<cost type="percentage">-20</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Mass Conservation</name>
-			<reference>B85</reference>
-			<cost type="percentage">-20</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Active Change</name>
-			<reference>P75</reference>
-			<cost type="percentage">20</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Improvised Forms</name>
-			<reference>P75</reference>
-			<cost type="percentage">100</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Cosmic (For Improvised Forms)</name>
-			<reference>P75</reference>
-			<cost type="percentage">50</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>No Memorization Required</name>
-			<reference>P75</reference>
-			<cost type="percentage">50</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Cannot Memorize Forms</name>
-			<reference>P75</reference>
-			<cost type="percentage">-50</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Flawed</name>
-			<reference>P75</reference>
-			<cost type="percentage">-10</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Unliving Forms Only</name>
-			<reference>P75</reference>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-		</modifier>
-		<reference>B84</reference>
 	</advantage>
 </advantage_list>

--- a/Library/Powers/Powers Advantages.adq
+++ b/Library/Powers/Powers Advantages.adq
@@ -4,37 +4,37 @@
 		<name>Air</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Elemental</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P121</reference>
@@ -58,37 +58,37 @@
 		<name>Animal Control</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-20</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Nature</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P121</reference>
@@ -112,23 +112,23 @@
 		<name>Anti-Magic</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P122</reference>
 			<cost type="percentage">0</cost>
 			<affects>total</affects>
-			<reference>P122</reference>
 			<notes>Anti-Magic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<reference>P121</reference>
@@ -152,37 +152,37 @@
 		<name>Anti-Super</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Biological</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-20</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Nature</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Anti-Super</name>
+			<reference>P122</reference>
 			<cost type="percentage">0</cost>
 			<affects>total</affects>
-			<reference>P122</reference>
 		</modifier>
 		<reference>P122</reference>
 		<categories>
@@ -205,30 +205,30 @@
 		<name>Antipsi</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P122</reference>
 			<cost type="percentage">0</cost>
 			<affects>total</affects>
-			<reference>P122</reference>
 			<notes>Antipsi</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Biological</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Chi</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P122</reference>
@@ -252,37 +252,37 @@
 		<name>Astral Projection</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-20</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Moral</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<reference>P122</reference>
@@ -310,21 +310,21 @@
 		<points_per_level>10</points_per_level>
 		<modifier version="1" enabled="no">
 			<name>Always On</name>
+			<reference>B93</reference>
 			<cost type="percentage">-20</cost>
 			<affects>total</affects>
-			<reference>B93</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Active</name>
+			<reference>P84</reference>
 			<cost type="percentage">0</cost>
 			<affects>total</affects>
-			<reference>P84</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Presence</name>
+			<reference>P84</reference>
 			<cost type="percentage">25</cost>
 			<affects>total</affects>
-			<reference>P84</reference>
 		</modifier>
 		<reference>P84</reference>
 		<categories>
@@ -335,30 +335,30 @@
 		<name>Bioenergy</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Biological</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Chi</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P123</reference>
@@ -382,30 +382,30 @@
 		<name>Body Alteration</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Biological</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P123</reference>
@@ -429,30 +429,30 @@
 		<name>Body Control</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Biological</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Chi</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P123</reference>
@@ -476,30 +476,30 @@
 		<name>Chaos</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-20</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Moral</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P124</reference>
@@ -523,23 +523,23 @@
 		<name>Cold/Ice</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Elemental</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P124</reference>
@@ -567,21 +567,21 @@
 		<points_per_level>10</points_per_level>
 		<modifier version="1" enabled="no">
 			<name>Always On</name>
+			<reference>B93</reference>
 			<cost type="percentage">-20</cost>
 			<affects>total</affects>
-			<reference>B93</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Active</name>
+			<reference>P84</reference>
 			<cost type="percentage">0</cost>
 			<affects>total</affects>
-			<reference>P84</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Presence</name>
+			<reference>P84</reference>
 			<cost type="percentage">25</cost>
 			<affects>total</affects>
-			<reference>P84</reference>
 		</modifier>
 		<reference>P84</reference>
 		<categories>
@@ -595,54 +595,54 @@
 		<points_per_level>5</points_per_level>
 		<modifier version="1" enabled="no">
 			<name>Persistent</name>
+			<reference>P91</reference>
 			<cost type="percentage">40</cost>
 			<affects>total</affects>
-			<reference>P91</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Ranged</name>
+			<reference>P91</reference>
 			<cost type="percentage">40</cost>
 			<affects>total</affects>
-			<reference>P91</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Collective</name>
+			<reference>P92</reference>
 			<cost type="percentage">100</cost>
 			<affects>total</affects>
-			<reference>P92</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Natural Phenomena</name>
+			<reference>P92</reference>
 			<cost type="percentage">100</cost>
 			<affects>total</affects>
-			<reference>P92</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Cosmetic</name>
+			<reference>P92</reference>
 			<cost type="percentage">-80</cost>
 			<affects>total</affects>
-			<reference>P92</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Super-Effort</name>
+			<reference>SU26</reference>
 			<cost type="percentage">400</cost>
 			<affects>total</affects>
-			<reference>SU26</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Rare</name>
-			<cost type="multiplier">2</cost>
 			<reference>P90</reference>
+			<cost type="multiplier">2</cost>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Occasional</name>
-			<cost type="multiplier">3</cost>
 			<reference>P90</reference>
+			<cost type="multiplier">3</cost>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Common</name>
-			<cost type="multiplier">4</cost>
 			<reference>P90</reference>
+			<cost type="multiplier">4</cost>
 		</modifier>
 		<reference>P90</reference>
 		<categories>
@@ -653,9 +653,9 @@
 		<name>Cosmic</name>
 		<modifier version="1">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">50</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Cosmic</notes>
 		</modifier>
 		<reference>P124</reference>
@@ -682,48 +682,48 @@
 		<points_per_level>5</points_per_level>
 		<modifier version="1" enabled="no">
 			<name>Destruction</name>
+			<reference>P94</reference>
 			<cost type="percentage">100</cost>
 			<affects>total</affects>
-			<reference>P94</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Destruction Only</name>
+			<reference>P94</reference>
 			<cost type="percentage">0</cost>
 			<affects>total</affects>
-			<reference>P94</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Transmutation</name>
+			<reference>P94</reference>
 			<cost type="percentage">50</cost>
 			<affects>total</affects>
-			<reference>P94</reference>
 			<notes>@Category@ to @Category@</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Transmutation only</name>
+			<reference>P94</reference>
 			<cost type="percentage">-100</cost>
 			<affects>total</affects>
-			<reference>P94</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Specific item</name>
-			<cost type="multiplier">1</cost>
 			<reference>P92</reference>
+			<cost type="multiplier">1</cost>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Small category</name>
-			<cost type="multiplier">2</cost>
 			<reference>P92</reference>
+			<cost type="multiplier">2</cost>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Medium category</name>
-			<cost type="multiplier">4</cost>
 			<reference>P92</reference>
+			<cost type="multiplier">4</cost>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Large category</name>
-			<cost type="multiplier">8</cost>
 			<reference>P92</reference>
+			<cost type="multiplier">8</cost>
 		</modifier>
 		<reference>P92</reference>
 		<categories>
@@ -734,30 +734,30 @@
 		<name>Darkness</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Elemental</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P125</reference>
@@ -781,23 +781,23 @@
 		<name>Death</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<reference>P125</reference>
@@ -821,37 +821,37 @@
 		<name>Dimensional Travel</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P125</reference>
@@ -875,9 +875,9 @@
 		<name>Divine (@Deity@)</name>
 		<modifier version="1">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<reference>P126</reference>
@@ -890,37 +890,37 @@
 		<name>Earth</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Elemental</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P126</reference>
@@ -944,23 +944,23 @@
 		<name>Electricity</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Elemental</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P126</reference>
@@ -984,16 +984,16 @@
 		<name>Electrokinesis</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P126</reference>
@@ -1020,48 +1020,48 @@
 		<points_per_level>3</points_per_level>
 		<modifier version="1" enabled="no">
 			<name>Abilities Only</name>
+			<reference>P119</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P119</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>One Power</name>
+			<reference>P117</reference>
 			<cost type="percentage">-50</cost>
 			<affects>total</affects>
-			<reference>P117</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Slow Recharge</name>
+			<reference>P117</reference>
 			<cost type="percentage">-20</cost>
 			<affects>total</affects>
-			<reference>P117</reference>
 			<notes>1/hour</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Slow Recharge</name>
+			<reference>P117</reference>
 			<cost type="percentage">-60</cost>
 			<affects>total</affects>
-			<reference>P117</reference>
 			<notes>1/day</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Special Recharge</name>
+			<reference>P117</reference>
 			<cost type="percentage">-70</cost>
 			<affects>total</affects>
-			<reference>P117</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Special Recharge</name>
+			<reference>P117</reference>
 			<cost type="percentage">-80</cost>
 			<affects>total</affects>
-			<reference>P117</reference>
 			<notes>1/s bleed</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Stunts Only</name>
+			<reference>P117</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P117</reference>
 		</modifier>
 		<reference>P119</reference>
 		<categories>
@@ -1073,37 +1073,37 @@
 		<name>ESP</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Chi</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P127</reference>
@@ -1127,30 +1127,30 @@
 		<name>Evil</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-20</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Moral</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<reference>P127</reference>
@@ -1185,23 +1185,23 @@
 		<name>Force Constructs</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P127</reference>
@@ -1214,30 +1214,30 @@
 		<name>Good</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-20</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Moral</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<reference>P128</reference>
@@ -1261,16 +1261,16 @@
 		<name>Gravity</name>
 		<modifier version="1" enabled="no">
 			<name>Power modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Elemental</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P128</reference>
@@ -1294,51 +1294,51 @@
 		<name>Healing</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Biological</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Chi</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P128</reference>
@@ -1351,51 +1351,51 @@
 		<name>Heat/Fire</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Elemental</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-20</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Moral</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P129</reference>
@@ -1408,37 +1408,37 @@
 		<name>Illusion</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-20</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Moral</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P129</reference>
@@ -1453,52 +1453,58 @@
 		<base_points>25</base_points>
 		<modifier version="1" enabled="no">
 			<name>Extended</name>
+			<reference>P95</reference>
 			<cost type="percentage">0</cost>
 			<affects>total</affects>
-			<reference>P95</reference>
 			<notes>@Sense@</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Independence</name>
+			<reference>P95</reference>
 			<cost type="percentage">50</cost>
 			<affects>total</affects>
-			<reference>P95</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Initiative</name>
+			<reference>P95</reference>
 			<cost type="percentage">100</cost>
 			<affects>total</affects>
-			<reference>P95</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Mental</name>
+			<reference>P95</reference>
 			<cost type="percentage">100</cost>
 			<affects>total</affects>
-			<reference>P95</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Stigmata</name>
+			<reference>P95</reference>
 			<cost type="percentage">100</cost>
 			<affects>total</affects>
-			<reference>P95</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Auditory Only</name>
+			<reference>P95</reference>
 			<cost type="percentage">-70</cost>
 			<affects>total</affects>
-			<reference>P95</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Static</name>
+			<reference>P95</reference>
 			<cost type="percentage">-30</cost>
 			<affects>total</affects>
-			<reference>P95</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Visual Only</name>
+			<reference>P95</reference>
 			<cost type="percentage">-30</cost>
 			<affects>total</affects>
-			<reference>P95</reference>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Hallucinations</name>
+			<reference>PSI14</reference>
+			<cost type="percentage">-50</cost>
+			<affects>total</affects>
 		</modifier>
 		<reference>P94</reference>
 		<categories>
@@ -1512,30 +1518,30 @@
 		<points_per_level>25</points_per_level>
 		<modifier version="1" enabled="no">
 			<name>Limited</name>
+			<reference>B46</reference>
 			<cost type="percentage">-40</cost>
 			<affects>total</affects>
-			<reference>B46</reference>
 			<notes>@Common Attack Form@</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Limited</name>
+			<reference>B46</reference>
 			<cost type="percentage">-60</cost>
 			<affects>total</affects>
-			<reference>B46</reference>
 			<notes>@Occasional Attack Form@</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Limited</name>
+			<reference>B46</reference>
 			<cost type="percentage">-80</cost>
 			<affects>total</affects>
-			<reference>B46</reference>
 			<notes>@Rare Attack Form@</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Limited</name>
+			<reference>B46</reference>
 			<cost type="percentage">-20</cost>
 			<affects>total</affects>
-			<reference>B46</reference>
 			<notes>@Very Common Attack Form@</notes>
 		</modifier>
 		<reference>P53</reference>
@@ -1549,27 +1555,27 @@
 		<base_points>35</base_points>
 		<modifier version="1" enabled="no">
 			<name>Detachable Head</name>
+			<reference>P52</reference>
 			<cost type="percentage">15</cost>
 			<affects>total</affects>
-			<reference>P52</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Instant Reattachment</name>
+			<reference>P52</reference>
 			<cost type="percentage">50</cost>
 			<affects>total</affects>
-			<reference>P52</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>No Reattachment</name>
+			<reference>P52</reference>
 			<cost type="percentage">-60</cost>
 			<affects>total</affects>
-			<reference>P52</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Reattachment Only</name>
+			<reference>P52</reference>
 			<cost type="percentage">-50</cost>
 			<affects>total</affects>
-			<reference>P52</reference>
 		</modifier>
 		<reference>P53</reference>
 		<categories>
@@ -1657,39 +1663,39 @@
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Hazard: Dehydration</name>
+			<reference>B104</reference>
 			<cost type="percentage">20</cost>
 			<affects>total</affects>
-			<reference>B104</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Hazard: Drowning</name>
+			<reference>B104</reference>
 			<cost type="percentage">0</cost>
 			<affects>total</affects>
-			<reference>B104</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Hazard: Freezing</name>
+			<reference>B104</reference>
 			<cost type="percentage">20</cost>
 			<affects>total</affects>
-			<reference>B104</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Hazard: Missed Sleep</name>
+			<reference>B104</reference>
 			<cost type="percentage">50</cost>
 			<affects>total</affects>
-			<reference>B104</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Hazard: Starvation</name>
+			<reference>B104</reference>
 			<cost type="percentage">40</cost>
 			<affects>total</affects>
-			<reference>B104</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Hazard: Suffocation</name>
+			<reference>B104</reference>
 			<cost type="percentage">0</cost>
 			<affects>total</affects>
-			<reference>B104</reference>
 		</modifier>
 		<reference>P96</reference>
 		<categories>
@@ -1700,30 +1706,30 @@
 		<name>Life</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-20</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Nature</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<reference>P130</reference>
@@ -1736,30 +1742,30 @@
 		<name>Light</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Elemental</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P130</reference>
@@ -1772,16 +1778,16 @@
 		<name>Machine Telepathy</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P130</reference>
@@ -1794,9 +1800,9 @@
 		<name>Magic</name>
 		<modifier version="1">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<reference>P131</reference>
@@ -1809,16 +1815,16 @@
 		<name>Magnetism</name>
 		<modifier version="1" enabled="no">
 			<name>Power modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Elemental</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P131</reference>
@@ -1831,9 +1837,9 @@
 		<name>Matter Control</name>
 		<modifier version="1">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P131</reference>
@@ -1848,49 +1854,67 @@
 		<base_points>50</base_points>
 		<modifier version="1" enabled="no">
 			<name>Power Theft</name>
+			<reference>P97</reference>
 			<cost type="percentage">200</cost>
 			<affects>total</affects>
-			<reference>P97</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>One Power</name>
+			<reference>P97</reference>
 			<cost type="percentage">-50</cost>
 			<affects>total</affects>
-			<reference>P97</reference>
 			<notes>@Power@</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Cosmic</name>
+			<reference>P97</reference>
 			<cost type="percentage">300</cost>
 			<affects>total</affects>
-			<reference>P97</reference>
 			<notes>Any Source</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Theft</name>
+			<reference>P97</reference>
 			<cost type="percentage">300</cost>
 			<affects>total</affects>
-			<reference>P97</reference>
 			<notes>Point Total</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Precise</name>
+			<reference>P97</reference>
 			<cost type="percentage">20</cost>
 			<affects>total</affects>
-			<reference>P97</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Derange</name>
+			<reference>P97</reference>
 			<cost type="percentage">-20</cost>
 			<affects>total</affects>
-			<reference>P97</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>One Ability</name>
+			<reference>P97</reference>
 			<cost type="percentage">-80</cost>
 			<affects>total</affects>
-			<reference>P97</reference>
 			<notes>@Ability@ in @Power@</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Derangable</name>
+			<reference>PSI16</reference>
+			<cost type="percentage">10</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Power Theft, Weak</name>
+			<reference>PSI16</reference>
+			<cost type="percentage">100</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Interruption</name>
+			<reference>PSI16</reference>
+			<cost type="percentage">-50</cost>
+			<affects>total</affects>
 		</modifier>
 		<reference>P97</reference>
 		<categories>
@@ -1901,23 +1925,23 @@
 		<name>Order</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-20</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Moral</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<reference>P132</reference>
@@ -1930,37 +1954,37 @@
 		<name>Plant Control</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-20</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Nature</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P132</reference>
@@ -1973,121 +1997,121 @@
 		<name>Power</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Biological</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Chi</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">50</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Cosmic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Elemental</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-20</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Moral</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-20</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Nature</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>SU34</reference>
 			<cost type="percentage">-30</cost>
 			<affects>total</affects>
-			<reference>SU34</reference>
 			<notes>Electronic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>SU34</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>SU34</reference>
 			<notes>Mechanical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>SU34</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>SU34</reference>
 			<notes>Mutant</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>SU34</reference>
 			<cost type="percentage">-15</cost>
 			<affects>total</affects>
-			<reference>SU34</reference>
 			<notes>Nanotech</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>SU34</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>SU34</reference>
 			<notes>Savant</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>SU34</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>SU34</reference>
 			<notes>Superscience</notes>
 		</modifier>
 		<reference>P7</reference>
@@ -2112,37 +2136,37 @@
 		<name>Probability Alteration</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P132</reference>
@@ -2155,37 +2179,37 @@
 		<name>Psychokinesis</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P133</reference>
@@ -2198,16 +2222,16 @@
 		<name>Radiation</name>
 		<modifier version="1" enabled="no">
 			<name>Power modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Elemental</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P133</reference>
@@ -2220,23 +2244,23 @@
 		<name>Sound/Vibration</name>
 		<modifier version="1" enabled="no">
 			<name>Power modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Elemental</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P133</reference>
@@ -2249,23 +2273,23 @@
 		<name>Spirit Control</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<reference>P134</reference>
@@ -2280,28 +2304,40 @@
 		<base_points>30</base_points>
 		<modifier version="1" enabled="no">
 			<name>Area Effect</name>
+			<reference>P98</reference>
 			<cost type="percentage">50</cost>
 			<levels>1</levels>
 			<affects>total</affects>
-			<reference>P98</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Switchable</name>
+			<reference>P98</reference>
 			<cost type="percentage">100</cost>
 			<affects>total</affects>
-			<reference>P98</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Resistible</name>
+			<reference>P98</reference>
 			<cost type="percentage">-50</cost>
 			<affects>total</affects>
-			<reference>P98</reference>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Discriminatory</name>
+			<reference>P98</reference>
 			<cost type="percentage">150</cost>
 			<affects>total</affects>
-			<reference>P98</reference>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Tiring</name>
+			<reference>PSI17</reference>
+			<cost type="percentage">50</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>One Power</name>
+			<reference>PSI17</reference>
+			<cost type="percentage">-50</cost>
+			<affects>total</affects>
 		</modifier>
 		<reference>P98</reference>
 		<categories>
@@ -2312,30 +2348,30 @@
 		<name>Telepathy</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Biological</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P134</reference>
@@ -2348,23 +2384,23 @@
 		<name>Teleportation</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P134</reference>
@@ -2377,30 +2413,30 @@
 		<name>Time Mastery</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P135</reference>
@@ -2413,30 +2449,30 @@
 		<name>Vampirism</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Biological</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Psionic</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P135</reference>
@@ -2449,37 +2485,37 @@
 		<name>Water</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Elemental</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P135</reference>
@@ -2492,37 +2528,37 @@
 		<name>Weather Control</name>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P26</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P26</reference>
 			<notes>Divine</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P27</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P27</reference>
 			<notes>Magical</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-20</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Nature</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P28</reference>
 			<cost type="percentage">-25</cost>
 			<affects>total</affects>
-			<reference>P28</reference>
 			<notes>Spirit</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
 			<name>Power Modifier</name>
+			<reference>P29</reference>
 			<cost type="percentage">-10</cost>
 			<affects>total</affects>
-			<reference>P29</reference>
 			<notes>Super</notes>
 		</modifier>
 		<reference>P136</reference>

--- a/Library/Psionics/Psionics Advantages.adq
+++ b/Library/Psionics/Psionics Advantages.adq
@@ -1,2320 +1,3357 @@
 <?xml version="1.0" encoding="US-ASCII" ?>
 <advantage_list id="4a1c9802-f8dc-43bc-a1df-3750b319427b" version="1">
 	<advantage version="3">
-		<name>*Assistance with this Psionic Powers Library*</name>
-		<type></type>
+		<name>Modular Abilities (Slotted Cosmic Power)</name>
+		<type>Physical, Exotic</type>
+		<levels>1</levels>
+		<base_points>7</base_points>
+		<points_per_level>5</points_per_level>
 		<modifier version="1" enabled="no">
-			<name>0 point psionic abilities</name>
-			<cost type="percentage">0</cost>
+			<name>Physical Only</name>
+			<reference>B71</reference>
+			<cost type="percentage">50</cost>
 			<affects>total</affects>
-			<notes>Many psionic abilities in the GURPS Psionic Powers book do not have a fixed cost per level.  To deal with this, I used modifiers as a replacement for ability levels.  You only need 1 level active at a time (i.e. you do not need Interruption_2 and Interruption_1 active, only Interruption_2).</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
-			<name>Skills requiring an _ (underscore) as a prereq.</name>
-			<cost type="percentage">0</cost>
+			<name>Physical</name>
+			<reference>B71</reference>
+			<cost type="percentage">100</cost>
 			<affects>total</affects>
-			<notes>The underscore is related to the irregular points per level of some psionic abilities.  If a skill is red and says this is the problem, go to the related ability and activate a modifier to "level up" your ability.  All levels 1+ fulfil this requirement.</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
-			<name>Custom Psionic Powers</name>
-			<cost type="percentage">0</cost>
+			<name>Spells Only</name>
+			<reference>B71</reference>
+			<cost type="percentage">-20</cost>
 			<affects>total</affects>
-			<notes>Limited versions of psionic powers at reduced cost.  These are not compatible with the delimited version the power (i.e. Take either Telekinesis talent or Psychokinesis Talent, but not both.)</notes>
 		</modifier>
 		<modifier version="1" enabled="no">
-			<name>Questions, Comments, Errors</name>
-			<cost type="percentage">0</cost>
+			<name>Virtual</name>
+			<reference>B71</reference>
+			<cost type="percentage">-50</cost>
 			<affects>total</affects>
-			<notes>This is an early edition and is quite possibly riddled with errors.  I'd welcome any assistance; Send any comments to jdshue@mtu.edu</notes>
+			<notes>@Realm@</notes>
 		</modifier>
-		<notes>Helpful comments can be found in the modifiers of this advantage.</notes>
+		<reference>PSI15</reference>
+		<categories>
+			<category>Advantage</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Modular Abilities (Telepathic Learning)</name>
+		<type>Physical, Exotic</type>
+		<levels>1</levels>
+		<base_points>5</base_points>
+		<points_per_level>4</points_per_level>
+		<modifier version="1" enabled="no">
+			<name>Physical Only</name>
+			<reference>B71</reference>
+			<cost type="percentage">50</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Physical</name>
+			<reference>B71</reference>
+			<cost type="percentage">100</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Spells Only</name>
+			<reference>B71</reference>
+			<cost type="percentage">-20</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Virtual</name>
+			<reference>B71</reference>
+			<cost type="percentage">-50</cost>
+			<affects>total</affects>
+			<notes>@Realm@</notes>
+		</modifier>
+		<reference>PSI16</reference>
+		<categories>
+			<category>Advantage</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Enhanced Power Defence</name>
+		<type>Mental, Exotic</type>
+		<modifier version="1" enabled="no">
+			<name>One Psionic Skill (@Skill@)</name>
+			<reference>PSI18</reference>
+			<cost type="points">5</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>All Psionic Skills</name>
+			<reference>PSI18</reference>
+			<cost type="points">10</cost>
+			<affects>total</affects>
+		</modifier>
+		<reference>PSI18</reference>
+		<categories>
+			<category>Advantage</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Estatic Psi</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PSI19</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Gesalt Familiarity</name>
+		<type>Physical</type>
+		<reference>PSI19</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Weak Latency (@Power@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PSI19</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Weak Latency (Psi)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PSI19</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
 	</advantage>
 	<advantage_container version="3" open="yes">
-		<name>Anti-Psi</name>
-		<reference>PSI23</reference>
-		<categories>
-			<category>Anti-Psi</category>
-			<category>Psionics</category>
-		</categories>
+		<name>Psionic Powers</name>
 		<advantage version="3">
-			<name>Anti-Psi Talent</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>5</points_per_level>
-			<reference>PSI18</reference>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Power</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Cancellation</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Para-Invisibility</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Psionic Shield</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Screaming</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">True Sight</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Psychic Armor</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Psionic Resistance (All)</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Psionic Resistance</name>
-				<specialization compare="is anything">@Psionic ability for Psionic Resistance (if applicable)@</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Nullifying Armor</name>
-				<specialization compare="contains">Anti-Psi</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Strike of Negation</name>
-				<specialization compare="contains">Anti-Psi</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
+			<name>*Assistance with this Psionic Powers Library*</name>
+			<type></type>
+			<modifier version="1" enabled="no">
+				<name>0 point psionic abilities</name>
+				<cost type="percentage">0</cost>
+				<affects>total</affects>
+				<notes>Many psionic abilities in the GURPS Psionic Powers book do not have a fixed cost per level.  To deal with this, I used modifiers as a replacement for ability levels.  You only need 1 level active at a time (i.e. you do not need Interruption_2 and Interruption_1 active, only Interruption_2).</notes>
+			</modifier>
+			<modifier version="1" enabled="no">
+				<name>Skills requiring an _ (underscore) as a prereq.</name>
+				<cost type="percentage">0</cost>
+				<affects>total</affects>
+				<notes>The underscore is related to the irregular points per level of some psionic abilities.  If a skill is red and says this is the problem, go to the related ability and activate a modifier to "level up" your ability.  All levels 1+ fulfil this requirement.</notes>
+			</modifier>
+			<modifier version="1" enabled="no">
+				<name>Custom Psionic Powers</name>
+				<cost type="percentage">0</cost>
+				<affects>total</affects>
+				<notes>Limited versions of psionic powers at reduced cost.  These are not compatible with the delimited version the power (i.e. Take either Telekinesis talent or Psychokinesis Talent, but not both.)</notes>
+			</modifier>
+			<modifier version="1" enabled="no">
+				<name>Questions, Comments, Errors</name>
+				<cost type="percentage">0</cost>
+				<affects>total</affects>
+				<notes>This is an early edition and is quite possibly riddled with errors.  I'd welcome any assistance; Send any comments to jdshue@mtu.edu</notes>
+			</modifier>
+			<notes>Helpful comments can be found in the modifiers of this advantage.</notes>
 		</advantage>
-		<advantage version="3">
-			<name>Cancellation</name>
-			<type>Mental</type>
-			<modifier version="1" enabled="no">
-				<name>Cancellation_1</name>
-				<cost type="points">20</cost>
-				<affects>total</affects>
-				<notes>Skin-to-skin contact.</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Cancellation_2</name>
-				<cost type="points">35</cost>
-				<affects>total</affects>
-				<notes>Skin-to-skin contact. Can immediately retry after a failure.</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Cancellation_3</name>
-				<cost type="points">50</cost>
-				<affects>total</affects>
-				<notes>Any touch will suffice.</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Cancellation_4</name>
-				<cost type="points">70</cost>
-				<affects>total</affects>
-				<reference>B550</reference>
-				<notes>Can cancel someone at a distance; apply range penalties on p. B550</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Cancellation_5</name>
-				<cost type="points">95</cost>
-				<affects>total</affects>
-				<reference>B241</reference>
-				<notes>Can cancel someone at a distance; apply long-distance modifiers p. B241</notes>
-			</modifier>
+		<advantage_container version="3" open="no">
+			<name>Anti-Psi</name>
 			<reference>PSI23</reference>
-			<notes>Anti-Psi ability. Temporarily turn off all of target's psionic abilities. </notes>
 			<categories>
 				<category>Anti-Psi</category>
 				<category>Psionics</category>
 			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Gaze into the Abyss</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI24</reference>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Hostile Dampening</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI24</reference>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Interruption</name>
-			<type>Mental</type>
-			<modifier version="1" enabled="no">
-				<name>Interruption_1</name>
-				<cost type="points">10</cost>
-				<affects>total</affects>
-				<notes>Skin-to-skin contact.</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Interruption_2</name>
-				<cost type="points">35</cost>
-				<affects>total</affects>
-				<notes>Any brief touch will suffice.</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Interruption_3</name>
-				<cost type="points">50</cost>
-				<affects>total</affects>
-				<reference>B550</reference>
-				<notes>You can interrupt a connection at a distance.  Use range penalties p. B550</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Interruption_4</name>
-				<cost type="points">70</cost>
-				<affects>total</affects>
-				<reference>B241</reference>
-				<notes>You can interrupt a connection at a distance.  Use long-distance modifiers p. B241</notes>
-			</modifier>
-			<reference>PSI23</reference>
-			<notes>Anti-Psi ability. Interrupt a connection between a psi and his target.</notes>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Interruption (Have Cancellation)</name>
-			<type>Mental</type>
-			<modifier version="1" enabled="no">
-				<name>Interruption_1</name>
-				<cost type="points">0</cost>
-				<affects>total</affects>
-				<notes>Skin-to-skin contact.</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Interruption_2</name>
-				<cost type="points">0</cost>
-				<affects>total</affects>
-				<notes>Any brief touch will suffice.</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Interruption_3</name>
-				<cost type="points">0</cost>
-				<affects>total</affects>
-				<reference>B550</reference>
-				<notes>You can interrupt a connection at a distance.  Use range penalties p. B550</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Interruption_4</name>
-				<cost type="points">0</cost>
-				<affects>total</affects>
-				<reference>B241</reference>
-				<notes>You can interrupt a connection at a distance.  Use long-distance modifiers p. B241</notes>
-			</modifier>
-			<reference>PSI24</reference>
-			<notes>Anti-Psi ability. Interrupt a connection between a psi and his target.</notes>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Psionics</category>
-			</categories>
-			<prereq_list all="yes">
-				<advantage_prereq has="yes">
+			<advantage version="3">
+				<name>Anti-Psi Talent</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>5</points_per_level>
+				<reference>PSI18</reference>
+				<categories>
+					<category>Anti-Psi</category>
+					<category>Power</category>
+				</categories>
+				<skill_bonus>
 					<name compare="is">Cancellation</name>
-					<notes compare="contains">_</notes>
-				</advantage_prereq>
-			</prereq_list>
-		</advantage>
-		<advantage version="3">
-			<name>Major Psionic Resistance (All)</name>
-			<type>Mental</type>
-			<base_points>15</base_points>
-			<modifier version="1">
-				<name>Anti-Psi</name>
-				<cost type="percentage">0</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI26</reference>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Psionics</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Psionic Resistance (All)</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount>8</amount>
-			</skill_bonus>
-		</advantage>
-		<advantage version="3">
-			<name>Major Psionic Resistance to @Psionic ability@</name>
-			<type>Mental</type>
-			<base_points>7</base_points>
-			<modifier version="1">
-				<name>Anti-Psi</name>
-				<cost type="percentage">0</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI26</reference>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Psionics</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Psionic Resistance</name>
-				<specialization compare="is">@Psionic ability@</specialization>
-				<category compare="is anything"></category>
-				<amount>8</amount>
-			</skill_bonus>
-		</advantage>
-		<advantage version="3">
-			<name>Minor Psionic Resistance (All)</name>
-			<type>Mental</type>
-			<base_points>10</base_points>
-			<modifier version="1">
-				<name>Anti-Psi</name>
-				<cost type="percentage">0</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI26</reference>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Psionics</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Psionic Resistance (All)</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount>3</amount>
-			</skill_bonus>
-		</advantage>
-		<advantage version="3">
-			<name>Minor Psionic Resistance to @Psionic ability@</name>
-			<type>Mental</type>
-			<base_points>5</base_points>
-			<modifier version="1">
-				<name>Anti-Psi</name>
-				<cost type="percentage">0</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI26</reference>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Psionics</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Psionic Resistance</name>
-				<specialization compare="is anything">@Psionic ability@</specialization>
-				<category compare="is anything"></category>
-				<amount>3</amount>
-			</skill_bonus>
-		</advantage>
-		<advantage version="3">
-			<name>Nonthreatening</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI24</reference>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Para-Invisibility</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>5</points_per_level>
-			<reference>PSI23</reference>
-			<notes>Anti-Psi ability. Invisible to psionic detection.</notes>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Personal Awareness</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI24</reference>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Psi Static</name>
-			<type>Mental</type>
-			<base_points>30</base_points>
-			<modifier version="1">
-				<name>Anti-Psi</name>
-				<cost type="percentage">0</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI26</reference>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Psionic Overload</name>
-			<type>Mental</type>
-			<modifier version="1" enabled="no">
-				<name>Psionic Overload_1</name>
-				<cost type="points">25</cost>
-				<affects>total</affects>
-				<notes>Skin-to-skin contact.</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Psionic Overload_2</name>
-				<cost type="points">40</cost>
-				<affects>total</affects>
-				<notes>Any brief touch will suffice.</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Psionic Overload_3</name>
-				<cost type="points">60</cost>
-				<affects>total</affects>
-				<reference>B550</reference>
-				<notes>You can interrupt a connection at a distance.  Use range penalties p. B550</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Psionic Overload_4</name>
-				<cost type="points">85</cost>
-				<affects>total</affects>
-				<reference>B241</reference>
-				<notes>You can interrupt a connection at a distance.  Use long-distance modifiers p. B241</notes>
-			</modifier>
-			<reference>PSI23</reference>
-			<notes>Anti-Psi ability. Overload a psi's abilities, causing them to manifest uncontrollably.</notes>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Psionic Overload (Have Cancellation)</name>
-			<type>Mental</type>
-			<base_points>5</base_points>
-			<modifier version="1" enabled="no">
-				<name>Psionic Overload_1</name>
-				<cost type="points">0</cost>
-				<affects>total</affects>
-				<notes>Skin-to-skin contact.</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Psionic Overload_2</name>
-				<cost type="points">0</cost>
-				<affects>total</affects>
-				<notes>Any brief touch will suffice.</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Psionic Overload_3</name>
-				<cost type="points">0</cost>
-				<affects>total</affects>
-				<reference>B550</reference>
-				<notes>You can interrupt a connection at a distance.  Use range penalties p. B550</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Psionic Overload_4</name>
-				<cost type="points">0</cost>
-				<affects>total</affects>
-				<reference>B241</reference>
-				<notes>You can interrupt a connection at a distance.  Use long-distance modifiers p. B241</notes>
-			</modifier>
-			<reference>PSI24</reference>
-			<notes>Anti-Psi ability. Overload a psi's abilities, causing them to manifest uncontrollably.</notes>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Psionics</category>
-			</categories>
-			<prereq_list all="yes">
-				<advantage_prereq has="yes">
-					<name compare="is">Cancellation</name>
-					<notes compare="contains">_</notes>
-				</advantage_prereq>
-			</prereq_list>
-		</advantage>
-		<advantage version="3">
-			<name>Psionic Shield</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>2</points_per_level>
-			<reference>PSI24</reference>
-			<notes>Anti-Psi ability. Bonus to Will for resisting psionic mental intrusions. </notes>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Psychic Armor</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>8</points_per_level>
-			<reference>PSI25</reference>
-			<notes>Anti-Psi ability. Reduces damage taken from psionic attacks. </notes>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Screaming</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<base_points>-6</base_points>
-			<points_per_level>15</points_per_level>
-			<reference>PSI25</reference>
-			<notes>Anti-Psi ability. Mentally scream to interfere with psi usage.</notes>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Simple Defense</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI24</reference>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Skeptic</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI24</reference>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Tolerance</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI24</reference>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>True Sight (Anti-Psi)</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<base_points>11</base_points>
-			<points_per_level>5</points_per_level>
-			<reference>PSI23</reference>
-			<notes>Anti-Psi ability. Can see through psionic illusions.</notes>
-			<categories>
-				<category>Anti-Psi</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-	</advantage_container>
-	<advantage_container version="3" open="yes">
-		<name>Astral Projection</name>
-		<reference>PSI26</reference>
-		<categories>
-			<category>Astral Projection</category>
-			<category>Psionics</category>
-		</categories>
-		<advantage version="3">
-			<name>Astral Accessory</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI29</reference>
-			<categories>
-				<category>Astral Projection</category>
-				<category>Perk</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Astral Armor</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>3</points_per_level>
-			<reference>PSI26</reference>
-			<notes>Astral projection ability.  DR equal to astral armor level while astral projecting.</notes>
-			<categories>
-				<category>Astral Projection</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Astral Awareness</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI29</reference>
-			<categories>
-				<category>Astral Projection</category>
-				<category>Perk</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Astral Celerity</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>6</points_per_level>
-			<reference>PSI26</reference>
-			<notes>Astral projection ability. Increases move while astral projecting.</notes>
-			<categories>
-				<category>Astral Projection</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Astral Projection Talent</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>5</points_per_level>
-			<reference>PSI18</reference>
-			<categories>
-				<category>Astral Projection</category>
-				<category>Power</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Astral Armor</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Astral Movement</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Astral Sight</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Astral Travel</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Astral Sword</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Binding Shot</name>
-				<specialization compare="contains">Astral Projection</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Dancing Shield</name>
-				<specialization compare="contains">Astral Projection</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Dancing Weapon</name>
-				<specialization compare="contains">Astral Projection</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Ghostly Weapon</name>
-				<specialization compare="contains">Astral Projection</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Lighten Armor</name>
-				<specialization compare="contains">Astral Projection</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Penetrating Strike</name>
-				<specialization compare="contains">Astral Projection</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Spiritual Defense</name>
-				<specialization compare="contains">Astral Projection</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Stealthy Attack</name>
-				<specialization compare="contains">Astral Projection</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-		</advantage>
-		<advantage version="3">
-			<name>Astral Sight</name>
-			<type>Mental</type>
-			<modifier version="1" enabled="no">
-				<name>Astral Sight_1</name>
-				<cost type="points">6</cost>
-				<affects>total</affects>
-				<notes>You are completely blind to the secondary plane.</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Astral Sight_2</name>
-				<cost type="points">10</cost>
-				<affects>total</affects>
-				<notes>Semi-awareness of events on the secondary plane (-4 to vision rolls).</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Astral Sight_3</name>
-				<cost type="points">13</cost>
-				<affects>total</affects>
-				<notes>Observe both planes simultaneously without penalty. </notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Hearing</name>
-				<cost type="points">4</cost>
-				<affects>total</affects>
-				<notes>Can hear whispers from the observed plane. </notes>
-			</modifier>
-			<reference>PSI27</reference>
-			<notes>Astral projection ability. Can see entities on the astral plane while in the real world. </notes>
-			<categories>
-				<category>Astral Projection</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Astral Sword</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<base_points>2</base_points>
-			<points_per_level>6</points_per_level>
-			<melee_weapon>
-				<damage type="cut" base="1d-3"/>
-				<usage>Swing</usage>
-				<reach>C,1</reach>
-				<parry>0</parry>
-				<default>
-					<type>Skill</type>
-					<name>Astral Sword</name>
-					<modifier>0</modifier>
-				</default>
-				<default>
-					<type>Skill</type>
-					<name>Force Sword</name>
-					<modifier>-2</modifier>
-				</default>
-				<default>
-					<type>DX</type>
-					<modifier>-6</modifier>
-				</default>
-			</melee_weapon>
-			<reference>PSI28</reference>
-			<notes>Astral projection ability.  Manifest a sword of psionic energy on the astral plane. +1 damage/level. </notes>
-			<categories>
-				<category>Astral Projection</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Astral Travel</name>
-			<type>Mental</type>
-			<modifier version="1" enabled="no">
-				<name>Astral Travel_1</name>
-				<cost type="points">28</cost>
-				<affects>total</affects>
-				<notes>10 minutes actual time = 30 minutes on astral plane.</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Astral Travel_2</name>
-				<cost type="points">36</cost>
-				<affects>total</affects>
-				<notes>1 minute actual time = 30 minutes on astral plane.</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Astral Travel_3</name>
-				<cost type="points">48</cost>
-				<affects>total</affects>
-				<notes>1 minute actual time = 1 hour on astral plane.</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Astral Travel_4</name>
-				<cost type="points">56</cost>
-				<affects>total</affects>
-				<notes>4 seconds actual time = 1 hour on astral plane.</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Astral Travel_5</name>
-				<cost type="points">68</cost>
-				<affects>total</affects>
-				<notes>2 seconds actual time = 12 hours on astral plane.</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Astral Travel_6</name>
-				<cost type="points">80</cost>
-				<affects>total</affects>
-				<notes>1 second actual time = infinite time on astral plane.</notes>
-			</modifier>
-			<reference>PSI28</reference>
-			<notes>Astral projection ability. You can send your mind to the outer astral plane.</notes>
-			<categories>
-				<category>Astral Projection</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Doesn't Eat or Drink</name>
-			<type>Mental</type>
-			<base_points>10</base_points>
-			<modifier version="1">
-				<name>Astral Projection</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1">
-				<name>Only While Projecting</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI30</reference>
-			<categories>
-				<category>Astral Projection</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Doesn't Sleep</name>
-			<type>Mental</type>
-			<base_points>10</base_points>
-			<modifier version="1">
-				<name>Astral Projection</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1">
-				<name>Only While Projecting</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI30</reference>
-			<categories>
-				<category>Astral Projection</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Near-Death Projection</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI29</reference>
-			<categories>
-				<category>Astral Projection</category>
-				<category>Perk</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Projection Clock</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI29</reference>
-			<categories>
-				<category>Astral Projection</category>
-				<category>Perk</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Protected Power (Astral Projection)</name>
-			<type>Mental</type>
-			<base_points>5</base_points>
-			<modifier version="1">
-				<name>Astral Projection</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI30</reference>
-			<categories>
-				<category>Astral Projection</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Retractable Cord</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI29</reference>
-			<categories>
-				<category>Astral Projection</category>
-				<category>Perk</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Subjective Navigator</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI29</reference>
-			<categories>
-				<category>Astral Projection</category>
-				<category>Perk</category>
-			</categories>
-		</advantage>
-	</advantage_container>
-	<advantage_container version="3" open="yes">
-		<name>Custom Psionic Powers</name>
-		<categories>
-			<category>Power</category>
-		</categories>
-		<advantage version="3">
-			<name>Communication Talent</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>3</points_per_level>
-			<notes>Limited Telepathy talent. Incompatible with telepathy talent.</notes>
-			<categories>
-				<category>Communication</category>
-				<category>Power</category>
-				<category>Telepathy</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Borrow Skill</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Emotion Sense</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Telereceive</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Telesend</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<prereq_list all="yes">
-				<advantage_prereq has="no">
-					<name compare="is">Telepathy Talent</name>
-					<notes compare="is anything"></notes>
-					<level compare="at least">1</level>
-				</advantage_prereq>
-			</prereq_list>
-		</advantage>
-		<advantage version="3">
-			<name>Control Talent</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>3</points_per_level>
-			<notes>Limited Telepathy talent. Incompatible with telepathy talent.</notes>
-			<categories>
-				<category>Communication</category>
-				<category>Power</category>
-				<category>Telepathy</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Aspect</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Mental Surgery</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Mind Swap</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Mindwipe</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Sensory Control</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Suggestion</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Telecontrol</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<prereq_list all="yes">
-				<advantage_prereq has="no">
-					<name compare="is">Telepathy Talent</name>
-					<notes compare="is anything"></notes>
-					<level compare="at least">1</level>
-				</advantage_prereq>
-			</prereq_list>
-		</advantage>
-		<advantage version="3">
-			<name>Cyberpsi Talent</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>3</points_per_level>
-			<notes>Limited ergokinesis talent. Incompatible with ergokinesis talent.</notes>
-			<categories>
-				<category>Cyberpsi</category>
-				<category>Ergokinesis</category>
-				<category>Power</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Data Retrieval</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Netrunning</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Remote Control</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">I/O Tap</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<prereq_list all="yes">
-				<advantage_prereq has="no">
-					<name compare="is">Ergokinesis</name>
-					<notes compare="is anything"></notes>
-				</advantage_prereq>
-			</prereq_list>
-		</advantage>
-		<advantage version="3">
-			<name>Divination Talent</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>3</points_per_level>
-			<notes>Limited ESP talent. Incompatible with ESP talent.</notes>
-			<categories>
-				<category>Divination</category>
-				<category>ESP</category>
-				<category>Power</category>
-				<category>Psionics</category>
-				<category>Remote Senses</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Common Sense</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Danger Sense</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Illuminated</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Oracle</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Psychic Hunches</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Racial Memory</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Combat Sense</name>
-				<specialization compare="is">Divination</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Prognostication</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Psi Sense</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Retrocognition</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Visions</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<prereq_list all="no">
-				<advantage_prereq has="no">
-					<name compare="is">ESP Talent</name>
-					<notes compare="is anything"></notes>
-					<level compare="at least">1</level>
-				</advantage_prereq>
-			</prereq_list>
-		</advantage>
-		<advantage version="3">
-			<name>Electrokinesis Talent</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>3</points_per_level>
-			<notes>Limited ergokinesis talent. Incompatible with ergokinesis talent.</notes>
-			<categories>
-				<category>Cyberpsi</category>
-				<category>Ergokinesis</category>
-				<category>Power</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Confuse</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Dampen</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">EK Shield</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Electric Vision</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Lightning</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Radar Sense</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Surge</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Annihilating Weapon</name>
-				<specialization compare="contains">Electrokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Burning Strike</name>
-				<specialization compare="contains">Electrokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Electric Weapon</name>
-				<specialization compare="contains">Electrokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Fireproof Armor</name>
-				<specialization compare="contains">Electrokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Incendiary Weapon</name>
-				<specialization compare="contains">Electrokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Insulated Armor</name>
-				<specialization compare="contains">Electrokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Shockwave</name>
-				<specialization compare="contains">Electrokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<prereq_list all="yes">
-				<advantage_prereq has="no">
-					<name compare="is">Ergokinesis</name>
-					<notes compare="is anything"></notes>
-				</advantage_prereq>
-			</prereq_list>
-		</advantage>
-		<advantage version="3">
-			<name>Offense Talent</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>3</points_per_level>
-			<notes>Limited Telepathy talent. Incompatible with telepathy talent.</notes>
-			<categories>
-				<category>Communication</category>
-				<category>Power</category>
-				<category>Telepathy</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Instill Fear</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Mental Blow</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Mental Stab</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Sleep (Telepathy)</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<prereq_list all="yes">
-				<advantage_prereq has="no">
-					<name compare="is">Telepathy Talent</name>
-					<notes compare="is anything"></notes>
-					<level compare="at least">1</level>
-				</advantage_prereq>
-			</prereq_list>
-		</advantage>
-		<advantage version="3">
-			<name>Photokinesis Talent</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>3</points_per_level>
-			<notes>Limited ergokinesis talent. Incompatible with ergokinesis talent.</notes>
-			<categories>
-				<category>Ergokinesis</category>
-				<category>Photokinesis</category>
-				<category>Power</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Flash</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Hologram</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Photorefraction</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Blinding Defense</name>
-				<specialization compare="contains">Photokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Dazzling Display</name>
-				<specialization compare="contains">Photokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Stealthy Attack</name>
-				<specialization compare="contains">Photokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Subtle Defense</name>
-				<specialization compare="contains">Photokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<prereq_list all="yes">
-				<advantage_prereq has="no">
-					<name compare="is">Ergokinesis</name>
-					<notes compare="is anything"></notes>
-				</advantage_prereq>
-			</prereq_list>
-		</advantage>
-		<advantage version="3">
-			<name>Remote Senses Talent</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>3</points_per_level>
-			<notes>Limited ESP talent. Incompatible with ESP talent.</notes>
-			<categories>
-				<category>Divination</category>
-				<category>ESP</category>
-				<category>Power</category>
-				<category>Psionics</category>
-				<category>Remote Senses</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Psidar</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Seekersense</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Spirit Communication</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">True Sight (ESP)</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Awareness</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Clairvoyance</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<prereq_list all="no">
-				<advantage_prereq has="no">
-					<name compare="is">ESP Talent</name>
-					<notes compare="is anything"></notes>
-					<level compare="at least">1</level>
-				</advantage_prereq>
-			</prereq_list>
-		</advantage>
-		<advantage version="3">
-			<name>Sense and Defense Talent</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>3</points_per_level>
-			<notes>Limited Telepathy talent. Incompatible with telepathy talent.</notes>
-			<categories>
-				<category>Communication</category>
-				<category>Power</category>
-				<category>Telepathy</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Mind Clouding</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Mind Shield</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Telepathy Sense</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Telescan</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<prereq_list all="yes">
-				<advantage_prereq has="no">
-					<name compare="is">Telepathy Talent</name>
-					<notes compare="is anything"></notes>
-					<level compare="at least">1</level>
-				</advantage_prereq>
-			</prereq_list>
-		</advantage>
-		<advantage version="3">
-			<name>Telekinesis Talent</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>3</points_per_level>
-			<notes>Limited psychokinesis talent. Incompatible with psychokinesis talent.</notes>
-			<categories>
-				<category>Power</category>
-				<category>Psychokinesis</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">TK Grab</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">TK Crush</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">TK Bullet</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Levitation</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Telekinetic Control</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<prereq_list all="yes">
-				<advantage_prereq has="no">
-					<name compare="is">Psychokinesis Talent</name>
-					<notes compare="is anything"></notes>
-					<level compare="at least">1</level>
-				</advantage_prereq>
-			</prereq_list>
-		</advantage>
-	</advantage_container>
-	<advantage_container version="3" open="yes">
-		<name>Ergokinesis</name>
-		<reference>PSI30</reference>
-		<categories>
-			<category>Cyberpsi</category>
-			<category>Electrokinesis</category>
-			<category>Ergokinesis</category>
-			<category>Photokinesis</category>
-			<category>Psionics</category>
-		</categories>
-		<advantage_container version="3" open="yes">
-			<name>Cyberpsi</name>
-			<reference>PSI30</reference>
-			<notes>Branch of Ergokinesis</notes>
-			<categories>
-				<category>Cyberpsi</category>
-				<category>Ergokinesis</category>
-				<category>Psionics</category>
-			</categories>
-			<advantage version="3">
-				<name>Data Retrieval</name>
-				<type>Mental</type>
-				<modifier version="1" enabled="no">
-					<name>Data Retrieval_1</name>
-					<cost type="points">8</cost>
-					<affects>total</affects>
-					<notes>Requires touching the computer or network cable.</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Data Retrieval_2</name>
-					<cost type="points">14</cost>
-					<affects>total</affects>
-					<notes>Data access at range; -1 penalty per yard of distance.</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Data Retrieval_3</name>
-					<cost type="points">16</cost>
-					<affects>total</affects>
-					<reference>B550</reference>
-					<notes>Data access at range using normal range penalties on p. B550</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Data Retrieval_4</name>
-					<cost type="points">26</cost>
-					<affects>total</affects>
-					<reference>B241</reference>
-					<notes>Data access at range using long-distance modifiers on p. B241</notes>
-				</modifier>
-				<reference>PSI30</reference>
-				<notes>Cyberpsi ability. Can retrieve files and info from computers. </notes>
-				<categories>
-					<category>Cyberpsi</category>
-					<category>Ergokinesis</category>
-					<category>Psionics</category>
-				</categories>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Para-Invisibility</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Psionic Shield</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Screaming</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">True Sight</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Psychic Armor</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Psionic Resistance (All)</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Psionic Resistance</name>
+					<specialization compare="is anything">@Psionic ability for Psionic Resistance (if applicable)@</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Nullifying Armor</name>
+					<specialization compare="contains">Anti-Psi</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Strike of Negation</name>
+					<specialization compare="contains">Anti-Psi</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
 			</advantage>
 			<advantage version="3">
-				<name>I/O Tap</name>
+				<name>Cancellation</name>
 				<type>Mental</type>
 				<modifier version="1" enabled="no">
-					<name>I/O Tap_1</name>
-					<cost type="points">6</cost>
-					<affects>total</affects>
-					<notes>Requires touching the computer or network cable.</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>I/O Tap_2</name>
-					<cost type="points">9</cost>
-					<affects>total</affects>
-					<notes>I/O tap at range; -1 penalty per yard of distance.</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>I/O Tap_3</name>
-					<cost type="points">12</cost>
-					<affects>total</affects>
-					<reference>B550</reference>
-					<notes>I/O Tap at range using normal range penalties on p. B550</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>I/O Tap_4</name>
-					<cost type="points">27</cost>
-					<affects>total</affects>
-					<reference>B241</reference>
-					<notes>I/O Tap at range using long-distance modifiers on p. B241</notes>
-				</modifier>
-				<reference>PSI30</reference>
-				<notes>Cyberpsi ability. Monitor input and output from a single system.</notes>
-				<categories>
-					<category>Cyberpsi</category>
-					<category>Ergokinesis</category>
-					<category>Psionics</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Interface</name>
-				<type>Mental</type>
-				<base_points>1</base_points>
-				<reference>PSI35</reference>
-				<categories>
-					<category>Cyberpsi</category>
-					<category>Ergokinesis</category>
-					<category>Perk</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Netrunning</name>
-				<type>Mental</type>
-				<modifier version="1" enabled="no">
-					<name>Netrunning_1</name>
+					<name>Cancellation_1</name>
 					<cost type="points">20</cost>
 					<affects>total</affects>
-					<notes>1 minute concentration</notes>
+					<notes>Skin-to-skin contact.</notes>
 				</modifier>
 				<modifier version="1" enabled="no">
-					<name>Netrunning_2</name>
-					<cost type="points">30</cost>
+					<name>Cancellation_2</name>
+					<cost type="points">35</cost>
 					<affects>total</affects>
-					<notes>4 seconds of concentration</notes>
+					<notes>Skin-to-skin contact. Can immediately retry after a failure.</notes>
 				</modifier>
 				<modifier version="1" enabled="no">
-					<name>Netrunning_3</name>
-					<cost type="points">40</cost>
-					<affects>total</affects>
-					<notes>2 seconds of concentration</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Netrunning_4</name>
+					<name>Cancellation_3</name>
 					<cost type="points">50</cost>
 					<affects>total</affects>
-					<notes>1 second of concentration</notes>
+					<notes>Any touch will suffice.</notes>
 				</modifier>
 				<modifier version="1" enabled="no">
-					<name>Netrunning_5</name>
-					<cost type="points">75</cost>
+					<name>Cancellation_4</name>
+					<reference>B550</reference>
+					<cost type="points">70</cost>
 					<affects>total</affects>
-					<notes>1 second of concentration; Stay in 3x longer</notes>
+					<notes>Can cancel someone at a distance; apply range penalties on p. B550</notes>
 				</modifier>
 				<modifier version="1" enabled="no">
-					<name>Netrunning_6</name>
-					<cost type="points">90</cost>
+					<name>Cancellation_5</name>
+					<reference>B241</reference>
+					<cost type="points">95</cost>
 					<affects>total</affects>
-					<notes>1 second of concentration; Stay in 6x longer</notes>
+					<notes>Can cancel someone at a distance; apply long-distance modifiers p. B241</notes>
 				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Netrunning_7</name>
-					<cost type="points">100</cost>
-					<affects>total</affects>
-					<notes>1 second of concentration; Stay in as long as desired</notes>
-				</modifier>
-				<reference>PSI30</reference>
-				<notes>Cyberpsi ability. You can project into and take over computer systems.  </notes>
+				<reference>PSI23</reference>
+				<notes>Anti-Psi ability. Temporarily turn off all of target's psionic abilities. </notes>
 				<categories>
-					<category>Cyberpsi</category>
-					<category>Ergokinesis</category>
+					<category>Anti-Psi</category>
 					<category>Psionics</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Phreaker</name>
+				<name>Gaze into the Abyss</name>
 				<type>Mental</type>
 				<base_points>1</base_points>
-				<reference>PSI35</reference>
+				<reference>PSI24</reference>
 				<categories>
-					<category>Cyberpsi</category>
-					<category>Ergokinesis</category>
+					<category>Anti-Psi</category>
 					<category>Perk</category>
+					<category>Psionics</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Remote Control</name>
+				<name>Hostile Dampening</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI24</reference>
+				<categories>
+					<category>Anti-Psi</category>
+					<category>Perk</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Interruption</name>
 				<type>Mental</type>
 				<modifier version="1" enabled="no">
-					<name>Remote Control_1</name>
+					<name>Interruption_1</name>
 					<cost type="points">10</cost>
 					<affects>total</affects>
-					<notes>Requires touching the computer or network cable.</notes>
+					<notes>Skin-to-skin contact.</notes>
 				</modifier>
 				<modifier version="1" enabled="no">
-					<name>Remote Control_2</name>
-					<cost type="points">15</cost>
+					<name>Interruption_2</name>
+					<cost type="points">35</cost>
 					<affects>total</affects>
-					<notes>Data access at range; -1 penalty per yard of distance.</notes>
+					<notes>Any brief touch will suffice.</notes>
 				</modifier>
 				<modifier version="1" enabled="no">
-					<name>Remote Control_3</name>
-					<cost type="points">20</cost>
-					<affects>total</affects>
+					<name>Interruption_3</name>
 					<reference>B550</reference>
-					<notes>Data access at range using normal range penalties on p. B550</notes>
+					<cost type="points">50</cost>
+					<affects>total</affects>
+					<notes>You can interrupt a connection at a distance.  Use range penalties p. B550</notes>
 				</modifier>
 				<modifier version="1" enabled="no">
-					<name>Remote Control_4</name>
-					<cost type="points">40</cost>
-					<affects>total</affects>
+					<name>Interruption_4</name>
 					<reference>B241</reference>
-					<notes>Data access at range using long-distance modifiers on p. B241</notes>
+					<cost type="points">70</cost>
+					<affects>total</affects>
+					<notes>You can interrupt a connection at a distance.  Use long-distance modifiers p. B241</notes>
 				</modifier>
-				<reference>PSI32</reference>
-				<notes>Cyberpsi ability. You can issue orders to a computer.</notes>
+				<reference>PSI23</reference>
+				<notes>Anti-Psi ability. Interrupt a connection between a psi and his target.</notes>
 				<categories>
-					<category>Cyberpsi</category>
-					<category>Ergokinesis</category>
+					<category>Anti-Psi</category>
 					<category>Psionics</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Universal Remote</name>
+				<name>Interruption (Have Cancellation)</name>
+				<type>Mental</type>
+				<modifier version="1" enabled="no">
+					<name>Interruption_1</name>
+					<cost type="points">0</cost>
+					<affects>total</affects>
+					<notes>Skin-to-skin contact.</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Interruption_2</name>
+					<cost type="points">0</cost>
+					<affects>total</affects>
+					<notes>Any brief touch will suffice.</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Interruption_3</name>
+					<reference>B550</reference>
+					<cost type="points">0</cost>
+					<affects>total</affects>
+					<notes>You can interrupt a connection at a distance.  Use range penalties p. B550</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Interruption_4</name>
+					<reference>B241</reference>
+					<cost type="points">0</cost>
+					<affects>total</affects>
+					<notes>You can interrupt a connection at a distance.  Use long-distance modifiers p. B241</notes>
+				</modifier>
+				<reference>PSI24</reference>
+				<notes>Anti-Psi ability. Interrupt a connection between a psi and his target.</notes>
+				<categories>
+					<category>Anti-Psi</category>
+					<category>Psionics</category>
+				</categories>
+				<prereq_list all="yes">
+					<advantage_prereq has="yes">
+						<name compare="is">Cancellation</name>
+						<notes compare="contains">_</notes>
+					</advantage_prereq>
+				</prereq_list>
+			</advantage>
+			<advantage version="3">
+				<name>Major Psionic Resistance (All)</name>
+				<type>Mental</type>
+				<base_points>15</base_points>
+				<modifier version="1">
+					<name>Anti-Psi</name>
+					<cost type="percentage">0</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI26</reference>
+				<categories>
+					<category>Anti-Psi</category>
+					<category>Psionics</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">Psionic Resistance (All)</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount>8</amount>
+				</skill_bonus>
+			</advantage>
+			<advantage version="3">
+				<name>Major Psionic Resistance to @Psionic ability@</name>
+				<type>Mental</type>
+				<base_points>7</base_points>
+				<modifier version="1">
+					<name>Anti-Psi</name>
+					<cost type="percentage">0</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI26</reference>
+				<categories>
+					<category>Anti-Psi</category>
+					<category>Psionics</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">Psionic Resistance</name>
+					<specialization compare="is">@Psionic ability@</specialization>
+					<category compare="is anything"></category>
+					<amount>8</amount>
+				</skill_bonus>
+			</advantage>
+			<advantage version="3">
+				<name>Minor Psionic Resistance (All)</name>
+				<type>Mental</type>
+				<base_points>10</base_points>
+				<modifier version="1">
+					<name>Anti-Psi</name>
+					<cost type="percentage">0</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI26</reference>
+				<categories>
+					<category>Anti-Psi</category>
+					<category>Psionics</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">Psionic Resistance (All)</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount>3</amount>
+				</skill_bonus>
+			</advantage>
+			<advantage version="3">
+				<name>Minor Psionic Resistance to @Psionic ability@</name>
+				<type>Mental</type>
+				<base_points>5</base_points>
+				<modifier version="1">
+					<name>Anti-Psi</name>
+					<cost type="percentage">0</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI26</reference>
+				<categories>
+					<category>Anti-Psi</category>
+					<category>Psionics</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">Psionic Resistance</name>
+					<specialization compare="is anything">@Psionic ability@</specialization>
+					<category compare="is anything"></category>
+					<amount>3</amount>
+				</skill_bonus>
+			</advantage>
+			<advantage version="3">
+				<name>Nonthreatening</name>
 				<type>Mental</type>
 				<base_points>1</base_points>
-				<reference>PSI35</reference>
+				<reference>PSI24</reference>
 				<categories>
-					<category>Cyberpsi</category>
-					<category>Ergokinesis</category>
+					<category>Anti-Psi</category>
 					<category>Perk</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Para-Invisibility</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>5</points_per_level>
+				<reference>PSI23</reference>
+				<notes>Anti-Psi ability. Invisible to psionic detection.</notes>
+				<categories>
+					<category>Anti-Psi</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Personal Awareness</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI24</reference>
+				<categories>
+					<category>Anti-Psi</category>
+					<category>Perk</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Psi Static</name>
+				<type>Mental</type>
+				<base_points>30</base_points>
+				<modifier version="1">
+					<name>Anti-Psi</name>
+					<cost type="percentage">0</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI26</reference>
+				<categories>
+					<category>Anti-Psi</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Psionic Overload</name>
+				<type>Mental</type>
+				<modifier version="1" enabled="no">
+					<name>Psionic Overload_1</name>
+					<cost type="points">25</cost>
+					<affects>total</affects>
+					<notes>Skin-to-skin contact.</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Psionic Overload_2</name>
+					<cost type="points">40</cost>
+					<affects>total</affects>
+					<notes>Any brief touch will suffice.</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Psionic Overload_3</name>
+					<reference>B550</reference>
+					<cost type="points">60</cost>
+					<affects>total</affects>
+					<notes>You can interrupt a connection at a distance.  Use range penalties p. B550</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Psionic Overload_4</name>
+					<reference>B241</reference>
+					<cost type="points">85</cost>
+					<affects>total</affects>
+					<notes>You can interrupt a connection at a distance.  Use long-distance modifiers p. B241</notes>
+				</modifier>
+				<reference>PSI23</reference>
+				<notes>Anti-Psi ability. Overload a psi's abilities, causing them to manifest uncontrollably.</notes>
+				<categories>
+					<category>Anti-Psi</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Psionic Overload (Have Cancellation)</name>
+				<type>Mental</type>
+				<base_points>5</base_points>
+				<modifier version="1" enabled="no">
+					<name>Psionic Overload_1</name>
+					<cost type="points">0</cost>
+					<affects>total</affects>
+					<notes>Skin-to-skin contact.</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Psionic Overload_2</name>
+					<cost type="points">0</cost>
+					<affects>total</affects>
+					<notes>Any brief touch will suffice.</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Psionic Overload_3</name>
+					<reference>B550</reference>
+					<cost type="points">0</cost>
+					<affects>total</affects>
+					<notes>You can interrupt a connection at a distance.  Use range penalties p. B550</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Psionic Overload_4</name>
+					<reference>B241</reference>
+					<cost type="points">0</cost>
+					<affects>total</affects>
+					<notes>You can interrupt a connection at a distance.  Use long-distance modifiers p. B241</notes>
+				</modifier>
+				<reference>PSI24</reference>
+				<notes>Anti-Psi ability. Overload a psi's abilities, causing them to manifest uncontrollably.</notes>
+				<categories>
+					<category>Anti-Psi</category>
+					<category>Psionics</category>
+				</categories>
+				<prereq_list all="yes">
+					<advantage_prereq has="yes">
+						<name compare="is">Cancellation</name>
+						<notes compare="contains">_</notes>
+					</advantage_prereq>
+				</prereq_list>
+			</advantage>
+			<advantage version="3">
+				<name>Psionic Shield</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>2</points_per_level>
+				<reference>PSI24</reference>
+				<notes>Anti-Psi ability. Bonus to Will for resisting psionic mental intrusions. </notes>
+				<categories>
+					<category>Anti-Psi</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Psychic Armor</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>8</points_per_level>
+				<reference>PSI25</reference>
+				<notes>Anti-Psi ability. Reduces damage taken from psionic attacks. </notes>
+				<categories>
+					<category>Anti-Psi</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Screaming</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<base_points>-6</base_points>
+				<points_per_level>15</points_per_level>
+				<reference>PSI25</reference>
+				<notes>Anti-Psi ability. Mentally scream to interfere with psi usage.</notes>
+				<categories>
+					<category>Anti-Psi</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Simple Defense</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI24</reference>
+				<categories>
+					<category>Anti-Psi</category>
+					<category>Perk</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Skeptic</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI24</reference>
+				<categories>
+					<category>Anti-Psi</category>
+					<category>Perk</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Tolerance</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI24</reference>
+				<categories>
+					<category>Anti-Psi</category>
+					<category>Perk</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>True Sight (Anti-Psi)</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<base_points>11</base_points>
+				<points_per_level>5</points_per_level>
+				<reference>PSI23</reference>
+				<notes>Anti-Psi ability. Can see through psionic illusions.</notes>
+				<categories>
+					<category>Anti-Psi</category>
+					<category>Psionics</category>
 				</categories>
 			</advantage>
 		</advantage_container>
-		<advantage_container version="3" open="yes">
-			<name>Electrokinesis</name>
-			<reference>PSI32</reference>
-			<notes>Branch of Ergokinesis</notes>
+		<advantage_container version="3" open="no">
+			<name>Astral Projection</name>
+			<reference>PSI26</reference>
 			<categories>
-				<category>Electrokinesis</category>
-				<category>Ergokinesis</category>
+				<category>Astral Projection</category>
 				<category>Psionics</category>
 			</categories>
 			<advantage version="3">
-				<name>Confuse</name>
+				<name>Astral Accessory</name>
 				<type>Mental</type>
-				<modifier version="1" enabled="no">
-					<name>Confuse_1</name>
-					<cost type="points">15</cost>
-					<affects>total</affects>
-					<notes>Requires skin-to-skin contact.</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Confuse_2</name>
-					<cost type="points">18</cost>
-					<affects>total</affects>
-					<notes>Any touch is sufficient.</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Confuse_3</name>
-					<cost type="points">21</cost>
-					<affects>total</affects>
-					<notes>Confuse access at range; -1 penalty per yard of distance.</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Confuse_4</name>
-					<cost type="points">26</cost>
-					<affects>total</affects>
-					<reference>B550</reference>
-					<notes>Confuse at range using normal range penalties on p. B550</notes>
-				</modifier>
-				<reference>PSI32</reference>
-				<notes>Electrokinesis ability. Mentally stun someone. </notes>
+				<base_points>1</base_points>
+				<reference>PSI29</reference>
 				<categories>
-					<category>Electrokinesis</category>
-					<category>Ergokinesis</category>
+					<category>Astral Projection</category>
+					<category>Perk</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Astral Armor</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>3</points_per_level>
+				<reference>PSI26</reference>
+				<notes>Astral projection ability.  DR equal to astral armor level while astral projecting.</notes>
+				<categories>
+					<category>Astral Projection</category>
 					<category>Psionics</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Dampen</name>
+				<name>Astral Awareness</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI29</reference>
+				<categories>
+					<category>Astral Projection</category>
+					<category>Perk</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Astral Celerity</name>
 				<type>Mental</type>
 				<levels>1</levels>
-				<points_per_level>12</points_per_level>
-				<reference>PSI33</reference>
-				<notes>Electrokinesis ability. Stop the flow of electricity through an area. </notes>
+				<points_per_level>6</points_per_level>
+				<reference>PSI26</reference>
+				<notes>Astral projection ability. Increases move while astral projecting.</notes>
 				<categories>
-					<category>Electrokinesis</category>
-					<category>Ergokinesis</category>
+					<category>Astral Projection</category>
 					<category>Psionics</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>EK Shield</name>
+				<name>Astral Projection Talent</name>
 				<type>Mental</type>
 				<levels>1</levels>
-				<points_per_level>4</points_per_level>
-				<reference>PSI33</reference>
-				<notes>Electrokinesis ability. Divert incoming energy attacks. </notes>
+				<points_per_level>5</points_per_level>
+				<reference>PSI18</reference>
 				<categories>
-					<category>Electrokinesis</category>
-					<category>Ergokinesis</category>
+					<category>Astral Projection</category>
+					<category>Power</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">Astral Armor</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Astral Movement</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Astral Sight</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Astral Travel</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Astral Sword</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Binding Shot</name>
+					<specialization compare="contains">Astral Projection</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Dancing Shield</name>
+					<specialization compare="contains">Astral Projection</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Dancing Weapon</name>
+					<specialization compare="contains">Astral Projection</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Ghostly Weapon</name>
+					<specialization compare="contains">Astral Projection</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Lighten Armor</name>
+					<specialization compare="contains">Astral Projection</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Penetrating Strike</name>
+					<specialization compare="contains">Astral Projection</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Spiritual Defense</name>
+					<specialization compare="contains">Astral Projection</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Stealthy Attack</name>
+					<specialization compare="contains">Astral Projection</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+			</advantage>
+			<advantage version="3">
+				<name>Astral Sight</name>
+				<type>Mental</type>
+				<modifier version="1" enabled="no">
+					<name>Astral Sight_1</name>
+					<cost type="points">6</cost>
+					<affects>total</affects>
+					<notes>You are completely blind to the secondary plane.</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Astral Sight_2</name>
+					<cost type="points">10</cost>
+					<affects>total</affects>
+					<notes>Semi-awareness of events on the secondary plane (-4 to vision rolls).</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Astral Sight_3</name>
+					<cost type="points">13</cost>
+					<affects>total</affects>
+					<notes>Observe both planes simultaneously without penalty. </notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Hearing</name>
+					<cost type="points">4</cost>
+					<affects>total</affects>
+					<notes>Can hear whispers from the observed plane. </notes>
+				</modifier>
+				<reference>PSI27</reference>
+				<notes>Astral projection ability. Can see entities on the astral plane while in the real world. </notes>
+				<categories>
+					<category>Astral Projection</category>
 					<category>Psionics</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Electric Vision</name>
+				<name>Astral Sword</name>
 				<type>Mental</type>
 				<levels>1</levels>
-				<base_points>4</base_points>
-				<points_per_level>4</points_per_level>
-				<reference>PSI33</reference>
-				<notes>Electrokinesis ability. You can see electric currents. </notes>
-				<categories>
-					<category>Electrokinesis</category>
-					<category>Ergokinesis</category>
-					<category>Psionics</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Lightning</name>
-				<type>Mental</type>
-				<levels>1</levels>
-				<points_per_level>12</points_per_level>
-				<ranged_weapon>
-					<damage type="" base="1d"/>
-					<usage>Beam</usage>
-					<accuracy>3</accuracy>
-					<range>50/100</range>
-					<rate_of_fire>1</rate_of_fire>
+				<base_points>2</base_points>
+				<points_per_level>6</points_per_level>
+				<melee_weapon>
+					<damage type="cut" base="1d-3"/>
+					<usage>Swing</usage>
+					<reach>C,1</reach>
+					<parry>0</parry>
 					<default>
-						<type>DX</type>
-						<modifier>-4</modifier>
+						<type>Skill</type>
+						<name>Astral Sword</name>
+						<modifier>0</modifier>
 					</default>
 					<default>
 						<type>Skill</type>
-						<name>Innate Attack</name>
-						<specialization>Beam</specialization>
-						<modifier>0</modifier>
+						<name>Force Sword</name>
+						<modifier>-2</modifier>
 					</default>
-				</ranged_weapon>
-				<reference>PSI33</reference>
-				<notes>Electrokinesis ability. Channel power from an electrical source into a bolt of lightning. </notes>
+					<default>
+						<type>DX</type>
+						<modifier>-6</modifier>
+					</default>
+				</melee_weapon>
+				<reference>PSI28</reference>
+				<notes>Astral projection ability.  Manifest a sword of psionic energy on the astral plane. +1 damage/level. </notes>
 				<categories>
-					<category>Electrokinesis</category>
-					<category>Ergokinesis</category>
-					<category>Psionics</category>
-				</categories>
-				<weapon_bonus>
-					<name compare="is">Lightning</name>
-					<specialization compare="is anything"></specialization>
-					<level compare="at least">1</level>
-					<category compare="is anything"></category>
-					<amount>1</amount>
-				</weapon_bonus>
-			</advantage>
-			<advantage version="3">
-				<name>Power Source</name>
-				<type>Mental</type>
-				<base_points>1</base_points>
-				<reference>PSI35</reference>
-				<categories>
-					<category>Electrokinesis</category>
-					<category>Ergokinesis</category>
-					<category>Perk</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Radar Sense</name>
-				<type>Mental</type>
-				<levels>1</levels>
-				<base_points>10</base_points>
-				<points_per_level>2</points_per_level>
-				<reference>PSI34</reference>
-				<notes>Electrokinesis ability. You emit and analyze a radar signal. </notes>
-				<categories>
-					<category>Electrokinesis</category>
-					<category>Ergokinesis</category>
+					<category>Astral Projection</category>
 					<category>Psionics</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Surge</name>
-				<type>Mental</type>
-				<levels>1</levels>
-				<points_per_level>11</points_per_level>
-				<reference>PSI34</reference>
-				<notes>Electrokinesis ability. Short out electrical devices.</notes>
-				<categories>
-					<category>Electrokinesis</category>
-					<category>Ergokinesis</category>
-					<category>Psionics</category>
-				</categories>
-			</advantage>
-		</advantage_container>
-		<advantage version="3">
-			<name>Ergokinesis Talent</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>5</points_per_level>
-			<reference>PSI19</reference>
-			<categories>
-				<category>Cyberpsi</category>
-				<category>Electrokinesis</category>
-				<category>Ergokinesis</category>
-				<category>Photokinesis</category>
-				<category>Power</category>
-				<category>Psionics</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Data Retrieval</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">I/O Tap</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Netrunning</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Remote Control</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Confuse</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Dampen</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">EK Shield</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Electric Vision</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Lightning</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Radar Sense</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Surge</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Flash</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Hologram</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Photorefraction</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Annihilating Weapon</name>
-				<specialization compare="contains">Ergokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Blinding Defense</name>
-				<specialization compare="contains">Ergokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Burning Strike</name>
-				<specialization compare="contains">Ergokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Dazzling Display</name>
-				<specialization compare="contains">Ergokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Electric Weapon</name>
-				<specialization compare="contains">Ergokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Fireproof Armor</name>
-				<specialization compare="contains">Ergokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Incendiary Weapon</name>
-				<specialization compare="contains">Ergokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Insulated Armor</name>
-				<specialization compare="contains">Ergokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Shockwave</name>
-				<specialization compare="contains">Ergokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Stealthy Attack</name>
-				<specialization compare="contains">Ergokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Subtle Defense</name>
-				<specialization compare="contains">Ergokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<prereq_list all="no">
-				<advantage_prereq has="no">
-					<name compare="is">Photokinesis Talent</name>
-					<notes compare="is anything"></notes>
-					<level compare="at least">1</level>
-				</advantage_prereq>
-				<advantage_prereq has="no">
-					<name compare="is">Electrokinesis Talent</name>
-					<notes compare="is anything"></notes>
-					<level compare="at least">1</level>
-				</advantage_prereq>
-				<advantage_prereq has="no">
-					<name compare="is">Cyberpsi Talent</name>
-					<notes compare="is anything"></notes>
-					<level compare="at least">1</level>
-				</advantage_prereq>
-			</prereq_list>
-		</advantage>
-		<advantage version="3">
-			<name>Hyperspectral Vision</name>
-			<type>Physical</type>
-			<base_points>25</base_points>
-			<modifier version="1">
-				<name>Ergokinesis</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI37</reference>
-			<categories>
-				<category>Ergokinesis</category>
-				<category>Photokinesis</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Infravision</name>
-			<type>Physical</type>
-			<base_points>10</base_points>
-			<modifier version="1">
-				<name>Ergokinesis</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI37</reference>
-			<categories>
-				<category>Ergokinesis</category>
-				<category>Photokinesis</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage_container version="3" open="yes">
-			<name>Photokinesis</name>
-			<reference>PSI34</reference>
-			<notes>Branch of Ergokinesis</notes>
-			<categories>
-				<category>Ergokinesis</category>
-				<category>Photokinesis</category>
-				<category>Psionics</category>
-			</categories>
-			<advantage version="3">
-				<name>Flash</name>
-				<type>Mental</type>
-				<levels>1</levels>
-				<base_points>17</base_points>
-				<points_per_level>5</points_per_level>
-				<reference>PSI35</reference>
-				<notes>A photokinesis ability.  Create a flash of light to dazzle and blind those nearby.</notes>
-				<categories>
-					<category>Ergokinesis</category>
-					<category>Photokinesis</category>
-					<category>Psionics</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Hologram</name>
+				<name>Astral Travel</name>
 				<type>Mental</type>
 				<modifier version="1" enabled="no">
-					<name>Hologram_1</name>
-					<cost type="points">10</cost>
-					<affects>total</affects>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Hologram_2</name>
-					<cost type="points">13</cost>
-					<affects>total</affects>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Hologram_3</name>
-					<cost type="points">15</cost>
-					<affects>total</affects>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Hologram_4</name>
-					<cost type="points">18</cost>
-					<affects>total</affects>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Hologram_5</name>
-					<cost type="points">20</cost>
-					<affects>total</affects>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Hologram_6</name>
-					<cost type="points">23</cost>
-					<affects>total</affects>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Hologram_7</name>
-					<cost type="points">25</cost>
-					<affects>total</affects>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Hologram_8</name>
+					<name>Astral Travel_1</name>
 					<cost type="points">28</cost>
 					<affects>total</affects>
+					<notes>10 minutes actual time = 30 minutes on astral plane.</notes>
 				</modifier>
 				<modifier version="1" enabled="no">
-					<name>Hologram_9</name>
-					<cost type="points">30</cost>
+					<name>Astral Travel_2</name>
+					<cost type="points">36</cost>
 					<affects>total</affects>
+					<notes>1 minute actual time = 30 minutes on astral plane.</notes>
 				</modifier>
 				<modifier version="1" enabled="no">
-					<name>Hologram_10</name>
-					<cost type="points">33</cost>
+					<name>Astral Travel_3</name>
+					<cost type="points">48</cost>
 					<affects>total</affects>
+					<notes>1 minute actual time = 1 hour on astral plane.</notes>
 				</modifier>
-				<reference>PSI35</reference>
-				<notes>Photokinesis ability.  Create realistic images out of light; Use p. Psi22 psionic range table.</notes>
+				<modifier version="1" enabled="no">
+					<name>Astral Travel_4</name>
+					<cost type="points">56</cost>
+					<affects>total</affects>
+					<notes>4 seconds actual time = 1 hour on astral plane.</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Astral Travel_5</name>
+					<cost type="points">68</cost>
+					<affects>total</affects>
+					<notes>2 seconds actual time = 12 hours on astral plane.</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Astral Travel_6</name>
+					<cost type="points">80</cost>
+					<affects>total</affects>
+					<notes>1 second actual time = infinite time on astral plane.</notes>
+				</modifier>
+				<reference>PSI28</reference>
+				<notes>Astral projection ability. You can send your mind to the outer astral plane.</notes>
 				<categories>
-					<category>Ergokinesis</category>
-					<category>Photokinesis</category>
+					<category>Astral Projection</category>
 					<category>Psionics</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Light Amplification</name>
+				<name>Doesn't Eat or Drink</name>
+				<type>Mental</type>
+				<base_points>10</base_points>
+				<modifier version="1">
+					<name>Astral Projection</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1">
+					<name>Only While Projecting</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI30</reference>
+				<categories>
+					<category>Astral Projection</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Doesn't Sleep</name>
+				<type>Mental</type>
+				<base_points>10</base_points>
+				<modifier version="1">
+					<name>Astral Projection</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1">
+					<name>Only While Projecting</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI30</reference>
+				<categories>
+					<category>Astral Projection</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Near-Death Projection</name>
 				<type>Mental</type>
 				<base_points>1</base_points>
-				<reference>PSI35</reference>
+				<reference>PSI29</reference>
 				<categories>
-					<category>Ergokinesis</category>
+					<category>Astral Projection</category>
 					<category>Perk</category>
-					<category>Photokinesis</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Photorefraction</name>
+				<name>Projection Clock</name>
 				<type>Mental</type>
-				<levels>1</levels>
-				<points_per_level>5</points_per_level>
-				<modifier version="1" enabled="no">
-					<name>Blocking</name>
-					<cost type="percentage">-20</cost>
+				<base_points>1</base_points>
+				<reference>PSI29</reference>
+				<categories>
+					<category>Astral Projection</category>
+					<category>Perk</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Protected Power (Astral Projection)</name>
+				<type>Mental</type>
+				<base_points>5</base_points>
+				<modifier version="1">
+					<name>Astral Projection</name>
+					<cost type="percentage">-10</cost>
 					<affects>total</affects>
 				</modifier>
-				<reference>PSI36</reference>
-				<notes>A photokinesis ability.  Create a flash of light to dazzle and blind those nearby.</notes>
+				<reference>PSI30</reference>
 				<categories>
-					<category>Ergokinesis</category>
-					<category>Photokinesis</category>
+					<category>Astral Projection</category>
 					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Retractable Cord</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI29</reference>
+				<categories>
+					<category>Astral Projection</category>
+					<category>Perk</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Subjective Navigator</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI29</reference>
+				<categories>
+					<category>Astral Projection</category>
+					<category>Perk</category>
 				</categories>
 			</advantage>
 		</advantage_container>
-		<advantage version="3">
-			<name>Protected Power (Ergokinesis)</name>
-			<type>Physical</type>
-			<base_points>5</base_points>
-			<modifier version="1">
-				<name>Ergokinesis</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI37</reference>
+		<advantage_container version="3" open="no">
+			<name>Custom Psionic Powers</name>
 			<categories>
-				<category>Cyberpsi</category>
-				<category>Electrokinesis</category>
-				<category>Ergokinesis</category>
-				<category>Photokinesis</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Protected Vision</name>
-			<type>Physical</type>
-			<base_points>5</base_points>
-			<modifier version="1">
-				<name>Ergokinesis</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI37</reference>
-			<categories>
-				<category>Ergokinesis</category>
-				<category>Photokinesis</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Ultravision</name>
-			<type>Physical</type>
-			<base_points>10</base_points>
-			<modifier version="1">
-				<name>Ergokinesis</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI37</reference>
-			<categories>
-				<category>Ergokinesis</category>
-				<category>Photokinesis</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-	</advantage_container>
-	<advantage_container version="3" open="yes">
-		<name>ESP</name>
-		<reference>PSI37</reference>
-		<categories>
-			<category>ESP</category>
-			<category>Psionics</category>
-		</categories>
-		<advantage version="3">
-			<name>Card Sharp</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI42</reference>
-			<categories>
-				<category>ESP</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Remote Senses</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Common Sense</name>
-			<type>Mental</type>
-			<base_points>10</base_points>
-			<modifier version="1">
-				<name>ESP</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI43</reference>
-			<categories>
-				<category>ESP</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Danger Sense</name>
-			<type>Mental</type>
-			<base_points>15</base_points>
-			<modifier version="1">
-				<name>ESP</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI43</reference>
-			<categories>
-				<category>ESP</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage_container version="3" open="yes">
-			<name>Divination</name>
-			<reference>PSI37</reference>
-			<notes>Branch of ESP</notes>
-			<categories>
-				<category>ESP</category>
-				<category>Psionics</category>
-				<category>Remote Senses</category>
+				<category>Power</category>
 			</categories>
 			<advantage version="3">
-				<name>Aspected Visions</name>
+				<name>Communication Talent</name>
 				<type>Mental</type>
-				<base_points>8</base_points>
-				<modifier version="1" enabled="no">
-					<name>Overwhelming</name>
-					<cost type="points">-3</cost>
-					<affects>total</affects>
-				</modifier>
-				<reference>PSI39</reference>
-				<notes>@Aspect@. Divination ability. You receive visions about a specific type of event. </notes>
+				<levels>1</levels>
+				<points_per_level>3</points_per_level>
+				<notes>Limited Telepathy talent. Incompatible with telepathy talent.</notes>
+				<categories>
+					<category>Communication</category>
+					<category>Power</category>
+					<category>Telepathy</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">Borrow Skill</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Emotion Sense</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Telereceive</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Telesend</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<prereq_list all="yes">
+					<advantage_prereq has="no">
+						<name compare="is">Telepathy Talent</name>
+						<notes compare="is anything"></notes>
+						<level compare="at least">1</level>
+					</advantage_prereq>
+				</prereq_list>
+			</advantage>
+			<advantage version="3">
+				<name>Control Talent</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>3</points_per_level>
+				<notes>Limited Telepathy talent. Incompatible with telepathy talent.</notes>
+				<categories>
+					<category>Communication</category>
+					<category>Power</category>
+					<category>Telepathy</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">Aspect</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Mental Surgery</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Mind Swap</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Mindwipe</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Sensory Control</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Suggestion</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Telecontrol</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<prereq_list all="yes">
+					<advantage_prereq has="no">
+						<name compare="is">Telepathy Talent</name>
+						<notes compare="is anything"></notes>
+						<level compare="at least">1</level>
+					</advantage_prereq>
+				</prereq_list>
+			</advantage>
+			<advantage version="3">
+				<name>Cyberpsi Talent</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>3</points_per_level>
+				<notes>Limited ergokinesis talent. Incompatible with ergokinesis talent.</notes>
+				<categories>
+					<category>Cyberpsi</category>
+					<category>Ergokinesis</category>
+					<category>Power</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">Data Retrieval</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Netrunning</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Remote Control</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">I/O Tap</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<prereq_list all="yes">
+					<advantage_prereq has="no">
+						<name compare="is">Ergokinesis</name>
+						<notes compare="is anything"></notes>
+					</advantage_prereq>
+				</prereq_list>
+			</advantage>
+			<advantage version="3">
+				<name>Divination Talent</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>3</points_per_level>
+				<notes>Limited ESP talent. Incompatible with ESP talent.</notes>
 				<categories>
 					<category>Divination</category>
 					<category>ESP</category>
+					<category>Power</category>
+					<category>Psionics</category>
+					<category>Remote Senses</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">Common Sense</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Danger Sense</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Illuminated</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Oracle</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Psychic Hunches</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Racial Memory</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Combat Sense</name>
+					<specialization compare="is">Divination</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Prognostication</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Psi Sense</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Retrocognition</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Visions</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<prereq_list all="no">
+					<advantage_prereq has="no">
+						<name compare="is">ESP Talent</name>
+						<notes compare="is anything"></notes>
+						<level compare="at least">1</level>
+					</advantage_prereq>
+				</prereq_list>
+			</advantage>
+			<advantage version="3">
+				<name>Electrokinesis Talent</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>3</points_per_level>
+				<notes>Limited ergokinesis talent. Incompatible with ergokinesis talent.</notes>
+				<categories>
+					<category>Cyberpsi</category>
+					<category>Ergokinesis</category>
+					<category>Power</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">Confuse</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Dampen</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">EK Shield</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Electric Vision</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Lightning</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Radar Sense</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Surge</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Annihilating Weapon</name>
+					<specialization compare="contains">Electrokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Burning Strike</name>
+					<specialization compare="contains">Electrokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Electric Weapon</name>
+					<specialization compare="contains">Electrokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Fireproof Armor</name>
+					<specialization compare="contains">Electrokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Incendiary Weapon</name>
+					<specialization compare="contains">Electrokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Insulated Armor</name>
+					<specialization compare="contains">Electrokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Shockwave</name>
+					<specialization compare="contains">Electrokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<prereq_list all="yes">
+					<advantage_prereq has="no">
+						<name compare="is">Ergokinesis</name>
+						<notes compare="is anything"></notes>
+					</advantage_prereq>
+				</prereq_list>
+			</advantage>
+			<advantage version="3">
+				<name>Offense Talent</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>3</points_per_level>
+				<notes>Limited Telepathy talent. Incompatible with telepathy talent.</notes>
+				<categories>
+					<category>Communication</category>
+					<category>Power</category>
+					<category>Telepathy</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">Instill Fear</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Mental Blow</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Mental Stab</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Sleep (Telepathy)</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<prereq_list all="yes">
+					<advantage_prereq has="no">
+						<name compare="is">Telepathy Talent</name>
+						<notes compare="is anything"></notes>
+						<level compare="at least">1</level>
+					</advantage_prereq>
+				</prereq_list>
+			</advantage>
+			<advantage version="3">
+				<name>Photokinesis Talent</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>3</points_per_level>
+				<notes>Limited ergokinesis talent. Incompatible with ergokinesis talent.</notes>
+				<categories>
+					<category>Ergokinesis</category>
+					<category>Photokinesis</category>
+					<category>Power</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">Flash</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Hologram</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Photorefraction</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Blinding Defense</name>
+					<specialization compare="contains">Photokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Dazzling Display</name>
+					<specialization compare="contains">Photokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Stealthy Attack</name>
+					<specialization compare="contains">Photokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Subtle Defense</name>
+					<specialization compare="contains">Photokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<prereq_list all="yes">
+					<advantage_prereq has="no">
+						<name compare="is">Ergokinesis</name>
+						<notes compare="is anything"></notes>
+					</advantage_prereq>
+				</prereq_list>
+			</advantage>
+			<advantage version="3">
+				<name>Remote Senses Talent</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>3</points_per_level>
+				<notes>Limited ESP talent. Incompatible with ESP talent.</notes>
+				<categories>
+					<category>Divination</category>
+					<category>ESP</category>
+					<category>Power</category>
+					<category>Psionics</category>
+					<category>Remote Senses</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">Psidar</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Seekersense</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Spirit Communication</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">True Sight (ESP)</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Awareness</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Clairvoyance</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<prereq_list all="no">
+					<advantage_prereq has="no">
+						<name compare="is">ESP Talent</name>
+						<notes compare="is anything"></notes>
+						<level compare="at least">1</level>
+					</advantage_prereq>
+				</prereq_list>
+			</advantage>
+			<advantage version="3">
+				<name>Sense and Defense Talent</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>3</points_per_level>
+				<notes>Limited Telepathy talent. Incompatible with telepathy talent.</notes>
+				<categories>
+					<category>Communication</category>
+					<category>Power</category>
+					<category>Telepathy</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">Mind Clouding</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Mind Shield</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Telepathy Sense</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Telescan</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<prereq_list all="yes">
+					<advantage_prereq has="no">
+						<name compare="is">Telepathy Talent</name>
+						<notes compare="is anything"></notes>
+						<level compare="at least">1</level>
+					</advantage_prereq>
+				</prereq_list>
+			</advantage>
+			<advantage version="3">
+				<name>Telekinesis Talent</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>3</points_per_level>
+				<notes>Limited psychokinesis talent. Incompatible with psychokinesis talent.</notes>
+				<categories>
+					<category>Power</category>
+					<category>Psychokinesis</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">TK Grab</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">TK Crush</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">TK Bullet</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Levitation</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Telekinetic Control</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<prereq_list all="yes">
+					<advantage_prereq has="no">
+						<name compare="is">Psychokinesis Talent</name>
+						<notes compare="is anything"></notes>
+						<level compare="at least">1</level>
+					</advantage_prereq>
+				</prereq_list>
+			</advantage>
+		</advantage_container>
+		<advantage_container version="3" open="no">
+			<name>Ergokinesis</name>
+			<reference>PSI30</reference>
+			<categories>
+				<category>Cyberpsi</category>
+				<category>Electrokinesis</category>
+				<category>Ergokinesis</category>
+				<category>Photokinesis</category>
+				<category>Psionics</category>
+			</categories>
+			<advantage_container version="3" open="yes">
+				<name>Cyberpsi</name>
+				<reference>PSI30</reference>
+				<notes>Branch of Ergokinesis</notes>
+				<categories>
+					<category>Cyberpsi</category>
+					<category>Ergokinesis</category>
+					<category>Psionics</category>
+				</categories>
+				<advantage version="3">
+					<name>Data Retrieval</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Data Retrieval_1</name>
+						<cost type="points">8</cost>
+						<affects>total</affects>
+						<notes>Requires touching the computer or network cable.</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Data Retrieval_2</name>
+						<cost type="points">14</cost>
+						<affects>total</affects>
+						<notes>Data access at range; -1 penalty per yard of distance.</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Data Retrieval_3</name>
+						<reference>B550</reference>
+						<cost type="points">16</cost>
+						<affects>total</affects>
+						<notes>Data access at range using normal range penalties on p. B550</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Data Retrieval_4</name>
+						<reference>B241</reference>
+						<cost type="points">26</cost>
+						<affects>total</affects>
+						<notes>Data access at range using long-distance modifiers on p. B241</notes>
+					</modifier>
+					<reference>PSI30</reference>
+					<notes>Cyberpsi ability. Can retrieve files and info from computers. </notes>
+					<categories>
+						<category>Cyberpsi</category>
+						<category>Ergokinesis</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>I/O Tap</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>I/O Tap_1</name>
+						<cost type="points">6</cost>
+						<affects>total</affects>
+						<notes>Requires touching the computer or network cable.</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>I/O Tap_2</name>
+						<cost type="points">9</cost>
+						<affects>total</affects>
+						<notes>I/O tap at range; -1 penalty per yard of distance.</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>I/O Tap_3</name>
+						<reference>B550</reference>
+						<cost type="points">12</cost>
+						<affects>total</affects>
+						<notes>I/O Tap at range using normal range penalties on p. B550</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>I/O Tap_4</name>
+						<reference>B241</reference>
+						<cost type="points">27</cost>
+						<affects>total</affects>
+						<notes>I/O Tap at range using long-distance modifiers on p. B241</notes>
+					</modifier>
+					<reference>PSI30</reference>
+					<notes>Cyberpsi ability. Monitor input and output from a single system.</notes>
+					<categories>
+						<category>Cyberpsi</category>
+						<category>Ergokinesis</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Interface</name>
+					<type>Mental</type>
+					<base_points>1</base_points>
+					<reference>PSI35</reference>
+					<categories>
+						<category>Cyberpsi</category>
+						<category>Ergokinesis</category>
+						<category>Perk</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Netrunning</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Netrunning_1</name>
+						<cost type="points">20</cost>
+						<affects>total</affects>
+						<notes>1 minute concentration</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Netrunning_2</name>
+						<cost type="points">30</cost>
+						<affects>total</affects>
+						<notes>4 seconds of concentration</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Netrunning_3</name>
+						<cost type="points">40</cost>
+						<affects>total</affects>
+						<notes>2 seconds of concentration</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Netrunning_4</name>
+						<cost type="points">50</cost>
+						<affects>total</affects>
+						<notes>1 second of concentration</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Netrunning_5</name>
+						<cost type="points">75</cost>
+						<affects>total</affects>
+						<notes>1 second of concentration; Stay in 3x longer</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Netrunning_6</name>
+						<cost type="points">90</cost>
+						<affects>total</affects>
+						<notes>1 second of concentration; Stay in 6x longer</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Netrunning_7</name>
+						<cost type="points">100</cost>
+						<affects>total</affects>
+						<notes>1 second of concentration; Stay in as long as desired</notes>
+					</modifier>
+					<reference>PSI30</reference>
+					<notes>Cyberpsi ability. You can project into and take over computer systems.  </notes>
+					<categories>
+						<category>Cyberpsi</category>
+						<category>Ergokinesis</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Phreaker</name>
+					<type>Mental</type>
+					<base_points>1</base_points>
+					<reference>PSI35</reference>
+					<categories>
+						<category>Cyberpsi</category>
+						<category>Ergokinesis</category>
+						<category>Perk</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Remote Control</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Remote Control_1</name>
+						<cost type="points">10</cost>
+						<affects>total</affects>
+						<notes>Requires touching the computer or network cable.</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Remote Control_2</name>
+						<cost type="points">15</cost>
+						<affects>total</affects>
+						<notes>Data access at range; -1 penalty per yard of distance.</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Remote Control_3</name>
+						<reference>B550</reference>
+						<cost type="points">20</cost>
+						<affects>total</affects>
+						<notes>Data access at range using normal range penalties on p. B550</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Remote Control_4</name>
+						<reference>B241</reference>
+						<cost type="points">40</cost>
+						<affects>total</affects>
+						<notes>Data access at range using long-distance modifiers on p. B241</notes>
+					</modifier>
+					<reference>PSI32</reference>
+					<notes>Cyberpsi ability. You can issue orders to a computer.</notes>
+					<categories>
+						<category>Cyberpsi</category>
+						<category>Ergokinesis</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Universal Remote</name>
+					<type>Mental</type>
+					<base_points>1</base_points>
+					<reference>PSI35</reference>
+					<categories>
+						<category>Cyberpsi</category>
+						<category>Ergokinesis</category>
+						<category>Perk</category>
+					</categories>
+				</advantage>
+			</advantage_container>
+			<advantage_container version="3" open="yes">
+				<name>Electrokinesis</name>
+				<reference>PSI32</reference>
+				<notes>Branch of Ergokinesis</notes>
+				<categories>
+					<category>Electrokinesis</category>
+					<category>Ergokinesis</category>
+					<category>Psionics</category>
+				</categories>
+				<advantage version="3">
+					<name>Confuse</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Confuse_1</name>
+						<cost type="points">15</cost>
+						<affects>total</affects>
+						<notes>Requires skin-to-skin contact.</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Confuse_2</name>
+						<cost type="points">18</cost>
+						<affects>total</affects>
+						<notes>Any touch is sufficient.</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Confuse_3</name>
+						<cost type="points">21</cost>
+						<affects>total</affects>
+						<notes>Confuse access at range; -1 penalty per yard of distance.</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Confuse_4</name>
+						<reference>B550</reference>
+						<cost type="points">26</cost>
+						<affects>total</affects>
+						<notes>Confuse at range using normal range penalties on p. B550</notes>
+					</modifier>
+					<reference>PSI32</reference>
+					<notes>Electrokinesis ability. Mentally stun someone. </notes>
+					<categories>
+						<category>Electrokinesis</category>
+						<category>Ergokinesis</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Dampen</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<points_per_level>12</points_per_level>
+					<reference>PSI33</reference>
+					<notes>Electrokinesis ability. Stop the flow of electricity through an area. </notes>
+					<categories>
+						<category>Electrokinesis</category>
+						<category>Ergokinesis</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>EK Shield</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<points_per_level>4</points_per_level>
+					<reference>PSI33</reference>
+					<notes>Electrokinesis ability. Divert incoming energy attacks. </notes>
+					<categories>
+						<category>Electrokinesis</category>
+						<category>Ergokinesis</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Electric Vision</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<base_points>4</base_points>
+					<points_per_level>4</points_per_level>
+					<reference>PSI33</reference>
+					<notes>Electrokinesis ability. You can see electric currents. </notes>
+					<categories>
+						<category>Electrokinesis</category>
+						<category>Ergokinesis</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Lightning</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<points_per_level>12</points_per_level>
+					<ranged_weapon>
+						<damage type="" base="1d"/>
+						<usage>Beam</usage>
+						<accuracy>3</accuracy>
+						<range>50/100</range>
+						<rate_of_fire>1</rate_of_fire>
+						<default>
+							<type>DX</type>
+							<modifier>-4</modifier>
+						</default>
+						<default>
+							<type>Skill</type>
+							<name>Innate Attack</name>
+							<specialization>Beam</specialization>
+							<modifier>0</modifier>
+						</default>
+					</ranged_weapon>
+					<reference>PSI33</reference>
+					<notes>Electrokinesis ability. Channel power from an electrical source into a bolt of lightning. </notes>
+					<categories>
+						<category>Electrokinesis</category>
+						<category>Ergokinesis</category>
+						<category>Psionics</category>
+					</categories>
+					<weapon_bonus>
+						<name compare="is">Lightning</name>
+						<specialization compare="is anything"></specialization>
+						<level compare="at least">1</level>
+						<category compare="is anything"></category>
+						<amount>1</amount>
+					</weapon_bonus>
+				</advantage>
+				<advantage version="3">
+					<name>Power Source</name>
+					<type>Mental</type>
+					<base_points>1</base_points>
+					<reference>PSI35</reference>
+					<categories>
+						<category>Electrokinesis</category>
+						<category>Ergokinesis</category>
+						<category>Perk</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Radar Sense</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<base_points>10</base_points>
+					<points_per_level>2</points_per_level>
+					<reference>PSI34</reference>
+					<notes>Electrokinesis ability. You emit and analyze a radar signal. </notes>
+					<categories>
+						<category>Electrokinesis</category>
+						<category>Ergokinesis</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Surge</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<points_per_level>11</points_per_level>
+					<reference>PSI34</reference>
+					<notes>Electrokinesis ability. Short out electrical devices.</notes>
+					<categories>
+						<category>Electrokinesis</category>
+						<category>Ergokinesis</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+			</advantage_container>
+			<advantage version="3">
+				<name>Ergokinesis Talent</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>5</points_per_level>
+				<reference>PSI19</reference>
+				<categories>
+					<category>Cyberpsi</category>
+					<category>Electrokinesis</category>
+					<category>Ergokinesis</category>
+					<category>Photokinesis</category>
+					<category>Power</category>
+					<category>Psionics</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">Data Retrieval</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">I/O Tap</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Netrunning</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Remote Control</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Confuse</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Dampen</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">EK Shield</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Electric Vision</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Lightning</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Radar Sense</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Surge</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Flash</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Hologram</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Photorefraction</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Annihilating Weapon</name>
+					<specialization compare="contains">Ergokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Blinding Defense</name>
+					<specialization compare="contains">Ergokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Burning Strike</name>
+					<specialization compare="contains">Ergokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Dazzling Display</name>
+					<specialization compare="contains">Ergokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Electric Weapon</name>
+					<specialization compare="contains">Ergokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Fireproof Armor</name>
+					<specialization compare="contains">Ergokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Incendiary Weapon</name>
+					<specialization compare="contains">Ergokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Insulated Armor</name>
+					<specialization compare="contains">Ergokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Shockwave</name>
+					<specialization compare="contains">Ergokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Stealthy Attack</name>
+					<specialization compare="contains">Ergokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Subtle Defense</name>
+					<specialization compare="contains">Ergokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<prereq_list all="no">
+					<advantage_prereq has="no">
+						<name compare="is">Photokinesis Talent</name>
+						<notes compare="is anything"></notes>
+						<level compare="at least">1</level>
+					</advantage_prereq>
+					<advantage_prereq has="no">
+						<name compare="is">Electrokinesis Talent</name>
+						<notes compare="is anything"></notes>
+						<level compare="at least">1</level>
+					</advantage_prereq>
+					<advantage_prereq has="no">
+						<name compare="is">Cyberpsi Talent</name>
+						<notes compare="is anything"></notes>
+						<level compare="at least">1</level>
+					</advantage_prereq>
+				</prereq_list>
+			</advantage>
+			<advantage version="3">
+				<name>Hyperspectral Vision</name>
+				<type>Physical</type>
+				<base_points>25</base_points>
+				<modifier version="1">
+					<name>Ergokinesis</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI37</reference>
+				<categories>
+					<category>Ergokinesis</category>
+					<category>Photokinesis</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Infravision</name>
+				<type>Physical</type>
+				<base_points>10</base_points>
+				<modifier version="1">
+					<name>Ergokinesis</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI37</reference>
+				<categories>
+					<category>Ergokinesis</category>
+					<category>Photokinesis</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage_container version="3" open="yes">
+				<name>Photokinesis</name>
+				<reference>PSI34</reference>
+				<notes>Branch of Ergokinesis</notes>
+				<categories>
+					<category>Ergokinesis</category>
+					<category>Photokinesis</category>
+					<category>Psionics</category>
+				</categories>
+				<advantage version="3">
+					<name>Flash</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<base_points>17</base_points>
+					<points_per_level>5</points_per_level>
+					<reference>PSI35</reference>
+					<notes>A photokinesis ability.  Create a flash of light to dazzle and blind those nearby.</notes>
+					<categories>
+						<category>Ergokinesis</category>
+						<category>Photokinesis</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Hologram</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Hologram_1</name>
+						<cost type="points">10</cost>
+						<affects>total</affects>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Hologram_2</name>
+						<cost type="points">13</cost>
+						<affects>total</affects>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Hologram_3</name>
+						<cost type="points">15</cost>
+						<affects>total</affects>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Hologram_4</name>
+						<cost type="points">18</cost>
+						<affects>total</affects>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Hologram_5</name>
+						<cost type="points">20</cost>
+						<affects>total</affects>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Hologram_6</name>
+						<cost type="points">23</cost>
+						<affects>total</affects>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Hologram_7</name>
+						<cost type="points">25</cost>
+						<affects>total</affects>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Hologram_8</name>
+						<cost type="points">28</cost>
+						<affects>total</affects>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Hologram_9</name>
+						<cost type="points">30</cost>
+						<affects>total</affects>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Hologram_10</name>
+						<cost type="points">33</cost>
+						<affects>total</affects>
+					</modifier>
+					<reference>PSI35</reference>
+					<notes>Photokinesis ability.  Create realistic images out of light; Use p. Psi22 psionic range table.</notes>
+					<categories>
+						<category>Ergokinesis</category>
+						<category>Photokinesis</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Light Amplification</name>
+					<type>Mental</type>
+					<base_points>1</base_points>
+					<reference>PSI35</reference>
+					<categories>
+						<category>Ergokinesis</category>
+						<category>Perk</category>
+						<category>Photokinesis</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Photorefraction</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<points_per_level>5</points_per_level>
+					<modifier version="1" enabled="no">
+						<name>Blocking</name>
+						<cost type="percentage">-20</cost>
+						<affects>total</affects>
+					</modifier>
+					<reference>PSI36</reference>
+					<notes>A photokinesis ability.  Create a flash of light to dazzle and blind those nearby.</notes>
+					<categories>
+						<category>Ergokinesis</category>
+						<category>Photokinesis</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+			</advantage_container>
+			<advantage version="3">
+				<name>Protected Power (Ergokinesis)</name>
+				<type>Physical</type>
+				<base_points>5</base_points>
+				<modifier version="1">
+					<name>Ergokinesis</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI37</reference>
+				<categories>
+					<category>Cyberpsi</category>
+					<category>Electrokinesis</category>
+					<category>Ergokinesis</category>
+					<category>Photokinesis</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Protected Vision</name>
+				<type>Physical</type>
+				<base_points>5</base_points>
+				<modifier version="1">
+					<name>Ergokinesis</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI37</reference>
+				<categories>
+					<category>Ergokinesis</category>
+					<category>Photokinesis</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Ultravision</name>
+				<type>Physical</type>
+				<base_points>10</base_points>
+				<modifier version="1">
+					<name>Ergokinesis</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI37</reference>
+				<categories>
+					<category>Ergokinesis</category>
+					<category>Photokinesis</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+		</advantage_container>
+		<advantage_container version="3" open="no">
+			<name>ESP</name>
+			<reference>PSI37</reference>
+			<categories>
+				<category>ESP</category>
+				<category>Psionics</category>
+			</categories>
+			<advantage version="3">
+				<name>Card Sharp</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI42</reference>
+				<categories>
+					<category>ESP</category>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Remote Senses</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Common Sense</name>
+				<type>Mental</type>
+				<base_points>10</base_points>
+				<modifier version="1">
+					<name>ESP</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI43</reference>
+				<categories>
+					<category>ESP</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Danger Sense</name>
+				<type>Mental</type>
+				<base_points>15</base_points>
+				<modifier version="1">
+					<name>ESP</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI43</reference>
+				<categories>
+					<category>ESP</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage_container version="3" open="yes">
+				<name>Divination</name>
+				<reference>PSI37</reference>
+				<notes>Branch of ESP</notes>
+				<categories>
+					<category>ESP</category>
+					<category>Psionics</category>
+					<category>Remote Senses</category>
+				</categories>
+				<advantage version="3">
+					<name>Aspected Visions</name>
+					<type>Mental</type>
+					<base_points>8</base_points>
+					<modifier version="1" enabled="no">
+						<name>Overwhelming</name>
+						<cost type="points">-3</cost>
+						<affects>total</affects>
+					</modifier>
+					<reference>PSI39</reference>
+					<notes>@Aspect@. Divination ability. You receive visions about a specific type of event. </notes>
+					<categories>
+						<category>Divination</category>
+						<category>ESP</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Combat Sense</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<points_per_level>24</points_per_level>
+					<reference>PSI37</reference>
+					<notes>Divination ability. You can sense incoming attacks. </notes>
+					<categories>
+						<category>Divination</category>
+						<category>ESP</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Know-It-All</name>
+					<type>Mental</type>
+					<base_points>1</base_points>
+					<reference>PSI42</reference>
+					<categories>
+						<category>Divination</category>
+						<category>ESP</category>
+						<category>Perk</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Prognostication</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<base_points>13</base_points>
+					<points_per_level>5</points_per_level>
+					<reference>PSI37</reference>
+					<notes>Divination ability. You can read a person's future. </notes>
+					<categories>
+						<category>Divination</category>
+						<category>ESP</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Retrocognition</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Retrocognition_1</name>
+						<cost type="points">14</cost>
+						<affects>total</affects>
+						<notes>Vague information</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Retrocognition_2</name>
+						<cost type="points">20</cost>
+						<affects>total</affects>
+						<notes>Useful information regarding the object or place</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Retrocognition_3</name>
+						<cost type="points">30</cost>
+						<affects>total</affects>
+						<notes>Receive visions easier</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Retrocognition_4</name>
+						<cost type="points">40</cost>
+						<affects>total</affects>
+						<notes>Clear and straightforward visions</notes>
+					</modifier>
+					<reference>PSI38</reference>
+					<notes>Divination ability. You can read a object's or area's past.</notes>
+					<categories>
+						<category>Divination</category>
+						<category>ESP</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Retrocognitive Flashbacks</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Retrocognitive Flashbacks_1</name>
+						<cost type="points">10</cost>
+						<affects>total</affects>
+						<notes>Vague information</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Retrocognitive Flashbacks_2</name>
+						<cost type="points">16</cost>
+						<affects>total</affects>
+						<notes>Useful information regarding the object or place</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Retrocognitive Flashbacks_3</name>
+						<cost type="points">26</cost>
+						<affects>total</affects>
+						<notes>Receive visions easier</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Retrocognitive Flashbacks_4</name>
+						<cost type="points">36</cost>
+						<affects>total</affects>
+						<notes>Clear and straightforward visions</notes>
+					</modifier>
+					<reference>PSI38</reference>
+					<notes>Divination ability. You receive flashes of events from the past.</notes>
+					<categories>
+						<category>Divination</category>
+						<category>ESP</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Retrocognitive Flashbacks (Have Retrocognition)</name>
+					<type>Mental</type>
+					<base_points>6</base_points>
+					<modifier version="1" enabled="no">
+						<name>Retrocognitive Flashbacks_1</name>
+						<cost type="points">0</cost>
+						<affects>total</affects>
+						<notes>Vague information</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Retrocognitive Flashbacks_2</name>
+						<cost type="points">0</cost>
+						<affects>total</affects>
+						<notes>Useful information regarding the object or place</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Retrocognitive Flashbacks_3</name>
+						<cost type="points">0</cost>
+						<affects>total</affects>
+						<notes>Receive visions easier</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Retrocognitive Flashbacks_4</name>
+						<cost type="points">0</cost>
+						<affects>total</affects>
+						<notes>Clear and straightforward visions</notes>
+					</modifier>
+					<reference>PSI38</reference>
+					<notes>Divination ability. You receive flashes of events from the past.</notes>
+					<categories>
+						<category>Divination</category>
+						<category>ESP</category>
+						<category>Psionics</category>
+					</categories>
+					<prereq_list all="yes">
+						<advantage_prereq has="yes">
+							<name compare="is">Retrocognition</name>
+							<notes compare="contains">_</notes>
+						</advantage_prereq>
+					</prereq_list>
+				</advantage>
+				<advantage version="3">
+					<name>Signature Sniffer</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Signature Sniffer_1</name>
+						<cost type="points">4</cost>
+						<affects>total</affects>
+						<notes>Rough estimate of time</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Signature Sniffer_2</name>
+						<cost type="points">9</cost>
+						<affects>total</affects>
+						<notes>Improved estimate of time</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Signature Sniffer_3</name>
+						<cost type="points">18</cost>
+						<affects>total</affects>
+						<notes>Know time precisely</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Signature Sniffer_4</name>
+						<cost type="points">28</cost>
+						<affects>total</affects>
+						<notes>Know time precisely</notes>
+					</modifier>
+					<reference>PSI38</reference>
+					<notes>Divination ability. You can detect psychic residue.</notes>
+					<categories>
+						<category>Divination</category>
+						<category>ESP</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Signature Sniffer (Have Psi Sense)</name>
+					<type>Mental</type>
+					<base_points>5</base_points>
+					<modifier version="1" enabled="no">
+						<name>Signature Sniffer_1</name>
+						<cost type="points">0</cost>
+						<affects>total</affects>
+						<notes>Rough estimate of time</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Signature Sniffer_2</name>
+						<cost type="points">0</cost>
+						<affects>total</affects>
+						<notes>Improved estimate of time</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Signature Sniffer_3</name>
+						<cost type="points">0</cost>
+						<affects>total</affects>
+						<notes>Know time precisely</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Signature Sniffer_4</name>
+						<cost type="points">0</cost>
+						<affects>total</affects>
+						<notes>Know time precisely</notes>
+					</modifier>
+					<reference>PSI38</reference>
+					<notes>Divination ability. You can detect psychic residue.</notes>
+					<categories>
+						<category>Divination</category>
+						<category>ESP</category>
+						<category>Psionics</category>
+					</categories>
+					<prereq_list all="no">
+						<advantage_prereq has="yes">
+							<name compare="is">Psi Sense</name>
+							<notes compare="contains">_</notes>
+						</advantage_prereq>
+					</prereq_list>
+				</advantage>
+				<advantage version="3">
+					<name>Visions (Aspected Dream)</name>
+					<type>Mental</type>
+					<base_points>1</base_points>
+					<reference>PSI42</reference>
+					<categories>
+						<category>Divination</category>
+						<category>ESP</category>
+						<category>Perk</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Visions (Dream)</name>
+					<type>Mental</type>
+					<base_points>5</base_points>
+					<reference>PSI39</reference>
+					<notes>Divination ability. You receive visions while asleep.</notes>
+					<categories>
+						<category>Divination</category>
+						<category>ESP</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Visions (Full)</name>
+					<type>Mental</type>
+					<base_points>20</base_points>
+					<reference>PSI39</reference>
+					<notes>Divination ability. Visions appear at appropriate times. </notes>
+					<categories>
+						<category>Divination</category>
+						<category>ESP</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Visions (Overwhelming)</name>
+					<type>Mental</type>
+					<base_points>15</base_points>
+					<reference>PSI39</reference>
+					<notes>Divination ability. Powerful visions leave you reeling. </notes>
+					<categories>
+						<category>Divination</category>
+						<category>ESP</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Visions (Second Sight)</name>
+					<type>Mental</type>
+					<base_points>5</base_points>
+					<reference>PSI39</reference>
+					<notes>Divination ability. You receive visions when encountering situations or people. </notes>
+					<categories>
+						<category>Divination</category>
+						<category>ESP</category>
+						<category>Psionics</category>
+					</categories>
+				</advantage>
+			</advantage_container>
+			<advantage version="3">
+				<name>Dowsing</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI42</reference>
+				<categories>
+					<category>ESP</category>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Remote Senses</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>ESP Talent</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>5</points_per_level>
+				<reference>PSI19</reference>
+				<categories>
+					<category>Divination</category>
+					<category>ESP</category>
+					<category>Power</category>
+					<category>Psionics</category>
+					<category>Remote Senses</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">Common Sense</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Danger Sense</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Illuminated</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Oracle</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Psidar</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Psychic Hunches</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Racial Memory</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Seekersense</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Spirit Communication</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">True Sight (ESP)</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Combat Sense</name>
+					<specialization compare="is">Divination</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Prognostication</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Psi Sense</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Retrocognition</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Visions</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Awareness</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Clairvoyance</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Arching Shot</name>
+					<specialization compare="contains">ESP</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Blunting Armor</name>
+					<specialization compare="contains">ESP</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Far Shot</name>
+					<specialization compare="contains">ESP</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Forceful Blow</name>
+					<specialization compare="contains">ESP</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Guided Weapon</name>
+					<specialization compare="contains">ESP</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Impenetrable Armor</name>
+					<specialization compare="contains">ESP</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Padded Armor</name>
+					<specialization compare="contains">ESP</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Reinforce Armor</name>
+					<specialization compare="contains">ESP</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Supreme Control</name>
+					<specialization compare="contains">ESP</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Traumatic Blow</name>
+					<specialization compare="contains">ESP</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<prereq_list all="no">
+					<advantage_prereq has="no">
+						<name compare="is">Divination Talent</name>
+						<notes compare="is anything"></notes>
+						<level compare="at least">1</level>
+					</advantage_prereq>
+					<advantage_prereq has="no">
+						<name compare="is">Remote Senses Talent</name>
+						<notes compare="is anything"></notes>
+						<level compare="at least">1</level>
+					</advantage_prereq>
+				</prereq_list>
+			</advantage>
+			<advantage version="3">
+				<name>Exposition Sense</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI42</reference>
+				<categories>
+					<category>ESP</category>
+					<category>Perk</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Forecast</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI42</reference>
+				<categories>
+					<category>ESP</category>
+					<category>Perk</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Illuminated</name>
+				<type>Mental</type>
+				<base_points>15</base_points>
+				<modifier version="1">
+					<name>ESP</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI43</reference>
+				<categories>
+					<category>ESP</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Insider Glance (Armoury)</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI42</reference>
+				<categories>
+					<category>ESP</category>
+					<category>Perk</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Insider Glance (Electronics)</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI42</reference>
+				<categories>
+					<category>ESP</category>
+					<category>Perk</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Insider Glance (Mechanic)</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI42</reference>
+				<categories>
+					<category>ESP</category>
+					<category>Perk</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Insider Glance (Repair)</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI42</reference>
+				<categories>
+					<category>ESP</category>
+					<category>Perk</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Oracle</name>
+				<type>Mental</type>
+				<base_points>15</base_points>
+				<modifier version="1">
+					<name>ESP</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI43</reference>
+				<categories>
+					<category>ESP</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Protected Power (ESP)</name>
+				<type>Mental</type>
+				<base_points>5</base_points>
+				<modifier version="1">
+					<name>ESP</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI43</reference>
+				<categories>
+					<category>ESP</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Psi Sense</name>
+				<type>Mental</type>
+				<modifier version="1" enabled="no">
+					<name>Psi Sense_1</name>
+					<cost type="points">8</cost>
+					<affects>total</affects>
+					<notes>Vague sense</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Psi Sense_2</name>
+					<cost type="points">13</cost>
+					<affects>total</affects>
+					<notes>Gives direction of nearest psi use</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Psi Sense_3</name>
+					<cost type="points">22</cost>
+					<affects>total</affects>
+					<notes>Direction and distance to nearest psi usage</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Psi Sense_4</name>
+					<cost type="points">32</cost>
+					<affects>total</affects>
+					<notes>Direction, distance, and ability of nearest psi usage</notes>
+				</modifier>
+				<reference>PSI41</reference>
+				<notes>Divination ability. You can sense nearby psionic activity. </notes>
+				<categories>
+					<category>ESP</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Psidar</name>
+				<type>Mental</type>
+				<modifier version="1" enabled="no">
+					<name>Psidar_1</name>
+					<cost type="points">9</cost>
+					<affects>total</affects>
+					<notes>Vague sense</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Psidar_2</name>
+					<cost type="points">14</cost>
+					<affects>total</affects>
+					<notes>Gives direction of nearest psi</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Psidar_3</name>
+					<cost type="points">19</cost>
+					<affects>total</affects>
+					<notes>Direction and distance to nearest psi</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Psidar_4</name>
+					<cost type="points">29</cost>
+					<affects>total</affects>
+					<notes>Direction, distance, and ability known by nearest psi</notes>
+				</modifier>
+				<reference>PSI41</reference>
+				<notes>Divination ability. You can sense nearby psis.</notes>
+				<categories>
+					<category>ESP</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Psychic Hunches</name>
+				<type>Mental</type>
+				<modifier version="1" enabled="no">
+					<name>Psychic Hunches_1</name>
+					<reference>B63</reference>
+					<cost type="points">14</cost>
+					<affects>total</affects>
+					<notes>As intuition, p. B63</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Psychic Hunches_2</name>
+					<cost type="points">29</cost>
+					<affects>total</affects>
+					<notes>On a success, GM will tell you the best option.</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Psychic Hunches_3</name>
+					<cost type="points">36</cost>
+					<affects>total</affects>
+					<notes>Best choice and how to approach it on a success. </notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Psychic Hunches_4</name>
+					<cost type="points">51</cost>
+					<affects>total</affects>
+					<notes>Passive ability.</notes>
+				</modifier>
+				<reference>PSI42</reference>
+				<notes>Divination ability. You have a knack for guessing correctly.</notes>
+				<categories>
+					<category>ESP</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Racial Memory</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<base_points>-10</base_points>
+				<points_per_level>25</points_per_level>
+				<modifier version="1">
+					<name>ESP</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI43</reference>
+				<categories>
+					<category>ESP</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage_container version="3" open="yes">
+				<name>Remote Senses</name>
+				<reference>PSI39</reference>
+				<notes>Branch of ESP</notes>
+				<categories>
+					<category>ESP</category>
+					<category>Psionics</category>
+					<category>Remote Senses</category>
+				</categories>
+				<advantage version="3">
+					<name>Awareness</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<base_points>7</base_points>
+					<points_per_level>2</points_per_level>
+					<reference>PSI39</reference>
+					<notes>Remote senses ability. You have psychic awareness of your immediate vacinity. </notes>
+					<categories>
+						<category>ESP</category>
+						<category>Psionics</category>
+						<category>Remote Senses</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Clairaudience (Have Clairvoyance)</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<base_points>5</base_points>
+					<reference>PSI40</reference>
+					<notes>Remote senses ability. You can project your sense of hearing away from your body.</notes>
+					<categories>
+						<category>ESP</category>
+						<category>Psionics</category>
+						<category>Remote Senses</category>
+					</categories>
+					<prereq_list all="yes">
+						<advantage_prereq has="yes">
+							<name compare="is">Clairvoyance</name>
+							<notes compare="is anything"></notes>
+							<level compare="at least">1</level>
+						</advantage_prereq>
+					</prereq_list>
+				</advantage>
+				<advantage version="3">
+					<name>Clairaudience</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<base_points>8</base_points>
+					<points_per_level>5</points_per_level>
+					<reference>PSI40</reference>
+					<notes>Remote senses ability. You can project your sense of hearing away from your body.</notes>
+					<categories>
+						<category>ESP</category>
+						<category>Psionics</category>
+						<category>Remote Senses</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Clairvoyance</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<base_points>8</base_points>
+					<points_per_level>5</points_per_level>
+					<reference>PSI40</reference>
+					<notes>Remote senses ability. You can project your sense of sight away from your body.</notes>
+					<categories>
+						<category>ESP</category>
+						<category>Psionics</category>
+						<category>Remote Senses</category>
+					</categories>
+				</advantage>
+			</advantage_container>
+			<advantage version="3">
+				<name>Seekersense</name>
+				<type>Mental</type>
+				<modifier version="1" enabled="no">
+					<name>Seekersense_1</name>
+					<reference>B550</reference>
+					<cost type="points">7</cost>
+					<affects>total</affects>
+					<notes>Use range penalties p. B550</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Seekersense_2</name>
+					<cost type="points">13</cost>
+					<affects>total</affects>
+					<notes>You can search for similar people or items. </notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Seekersense_3</name>
+					<reference>B241</reference>
+					<cost type="points">18</cost>
+					<affects>total</affects>
+					<notes>Use long-distance modifiers p. B241</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Seekersense_4</name>
+					<cost type="points">29</cost>
+					<affects>total</affects>
+					<notes>Fast seekersense (1 second)</notes>
+				</modifier>
+				<reference>PSI42</reference>
+				<notes>Divination ability. You can home in on anyone or anything under certain conditions.</notes>
+				<categories>
+					<category>ESP</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Spirit Communication</name>
+				<type>Mental</type>
+				<modifier version="1" enabled="no">
+					<name>Spirit Communication_1</name>
+					<cost type="points">8</cost>
+					<affects>total</affects>
+					<notes>Must share a language</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Spirit Communication_2</name>
+					<cost type="points">13</cost>
+					<affects>total</affects>
+					<notes>Sharing a language not necessary</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Spirit Communication_3</name>
+					<cost type="points">18</cost>
+					<affects>total</affects>
+					<notes>Can see and speak with spirits.</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Psychic Hunches_4</name>
+					<cost type="points">28</cost>
+					<affects>total</affects>
+					<notes>Others can see the spirits you're speaking with.</notes>
+				</modifier>
+				<reference>PSI43</reference>
+				<notes>Divination ability. You can speak with spirits. </notes>
+				<categories>
+					<category>ESP</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>True Sight (ESP)</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<base_points>11</base_points>
+				<points_per_level>4</points_per_level>
+				<reference>PSI43</reference>
+				<notes>Divination ability. As True sight anti-psi ability p. Psi25</notes>
+				<categories>
+					<category>ESP</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+		</advantage_container>
+		<advantage_container version="3" open="no">
+			<name>Probability Alteration</name>
+			<reference>PSI43</reference>
+			<categories>
+				<category>Probability Alteration</category>
+				<category>Psionics</category>
+			</categories>
+			<advantage version="3">
+				<name>Adjustment</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<base_points>6</base_points>
+				<points_per_level>4</points_per_level>
+				<reference>PSI44</reference>
+				<notes>Probability alteration ability.  You can affect the outcome of events. </notes>
+				<categories>
+					<category>Probability Alteration</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Coincidence</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>27</points_per_level>
+				<reference>PSI44</reference>
+				<notes>Probability alteration ability.  You can arrange coincidences.</notes>
+				<categories>
+					<category>Probability Alteration</category>
 					<category>Psionics</category>
 				</categories>
 			</advantage>
@@ -2323,3874 +3360,873 @@
 				<type>Mental</type>
 				<levels>1</levels>
 				<points_per_level>24</points_per_level>
-				<reference>PSI37</reference>
-				<notes>Divination ability. You can sense incoming attacks. </notes>
+				<reference>PSI45</reference>
+				<notes>Probability alteration ability. You can avoid attacks through luck.</notes>
 				<categories>
-					<category>Divination</category>
-					<category>ESP</category>
+					<category>Probability Alteration</category>
 					<category>Psionics</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Know-It-All</name>
-				<type>Mental</type>
-				<base_points>1</base_points>
-				<reference>PSI42</reference>
-				<categories>
-					<category>Divination</category>
-					<category>ESP</category>
-					<category>Perk</category>
-					<category>Psionics</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Prognostication</name>
+				<name>Curse</name>
 				<type>Mental</type>
 				<levels>1</levels>
-				<base_points>13</base_points>
+				<base_points>20</base_points>
+				<points_per_level>2</points_per_level>
+				<reference>PSI45</reference>
+				<notes>Probability alteration ability.  You can negatively affect someone's fate. </notes>
+				<categories>
+					<category>Probability Alteration</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Good Neighbor</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI44</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Probability Alteration</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Karma Bank</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI44</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Probability Alteration</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Loaded Dice</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI44</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Probability Alteration</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Lucky Break</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI44</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Probability Alteration</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Misfire Master</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI44</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Probability Alteration</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Moneyclip Magnet</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI44</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Probability Alteration</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Probability Alteration Talent</name>
+				<type>Mental</type>
+				<levels>1</levels>
 				<points_per_level>5</points_per_level>
-				<reference>PSI37</reference>
-				<notes>Divination ability. You can read a person's future. </notes>
+				<reference>PSI19</reference>
 				<categories>
-					<category>Divination</category>
-					<category>ESP</category>
+					<category>Power</category>
+					<category>Probability Alteration</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">Adjustment</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Arching Shot</name>
+					<specialization compare="contains">Probability Alteration</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Bank Shot</name>
+					<specialization compare="contains">Probability Alteration</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Blunting Armor</name>
+					<specialization compare="contains">Probability Alteration</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Coincidence</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Crushing Strike</name>
+					<specialization compare="contains">Probability Alteration</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Curse</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Combat Sense</name>
+					<specialization compare="is anything">Probability Alteration</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Expand Armor</name>
+					<specialization compare="contains">Probability Alteration</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Homing Weapon</name>
+					<specialization compare="contains">Probability Alteration</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Impenetrable Armor</name>
+					<specialization compare="contains">Probability Alteration</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Padded Armor</name>
+					<specialization compare="contains">Probability Alteration</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Reinforce Armor</name>
+					<specialization compare="contains">Probability Alteration</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Second Chance</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Weather Control</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Widen Shield</name>
+					<specialization compare="contains">Probability Alteration</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+			</advantage>
+			<advantage version="3">
+				<name>Protected Power (Probability Alteration)</name>
+				<type>Mental</type>
+				<base_points>5</base_points>
+				<modifier version="1">
+					<name>Astral Projection</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI46</reference>
+				<categories>
+					<category>Probability Alteration</category>
 					<category>Psionics</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Retrocognition</name>
+				<name>Second Chance</name>
 				<type>Mental</type>
-				<modifier version="1" enabled="no">
-					<name>Retrocognition_1</name>
-					<cost type="points">14</cost>
-					<affects>total</affects>
-					<notes>Vague information</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Retrocognition_2</name>
-					<cost type="points">20</cost>
-					<affects>total</affects>
-					<notes>Useful information regarding the object or place</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Retrocognition_3</name>
-					<cost type="points">30</cost>
-					<affects>total</affects>
-					<notes>Receive visions easier</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Retrocognition_4</name>
-					<cost type="points">40</cost>
-					<affects>total</affects>
-					<notes>Clear and straightforward visions</notes>
-				</modifier>
-				<reference>PSI38</reference>
-				<notes>Divination ability. You can read a object's or area's past.</notes>
+				<levels>1</levels>
+				<points_per_level>12</points_per_level>
+				<reference>PSI45</reference>
+				<notes>Probability alteration ability.  You can reroll an action.</notes>
 				<categories>
-					<category>Divination</category>
-					<category>ESP</category>
+					<category>Probability Alteration</category>
 					<category>Psionics</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Retrocognitive Flashbacks</name>
+				<name>Shopper's Blessing</name>
 				<type>Mental</type>
-				<modifier version="1" enabled="no">
-					<name>Retrocognitive Flashbacks_1</name>
-					<cost type="points">10</cost>
-					<affects>total</affects>
-					<notes>Vague information</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Retrocognitive Flashbacks_2</name>
-					<cost type="points">16</cost>
-					<affects>total</affects>
-					<notes>Useful information regarding the object or place</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Retrocognitive Flashbacks_3</name>
-					<cost type="points">26</cost>
-					<affects>total</affects>
-					<notes>Receive visions easier</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Retrocognitive Flashbacks_4</name>
-					<cost type="points">36</cost>
-					<affects>total</affects>
-					<notes>Clear and straightforward visions</notes>
-				</modifier>
-				<reference>PSI38</reference>
-				<notes>Divination ability. You receive flashes of events from the past.</notes>
+				<base_points>1</base_points>
+				<reference>PSI44</reference>
 				<categories>
-					<category>Divination</category>
-					<category>ESP</category>
+					<category>Perk</category>
+					<category>Probability Alteration</category>
 					<category>Psionics</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Retrocognitive Flashbacks (Have Retrocognition)</name>
+				<name>Weather Control</name>
 				<type>Mental</type>
-				<base_points>6</base_points>
-				<modifier version="1" enabled="no">
-					<name>Retrocognitive Flashbacks_1</name>
-					<cost type="points">0</cost>
-					<affects>total</affects>
-					<notes>Vague information</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Retrocognitive Flashbacks_2</name>
-					<cost type="points">0</cost>
-					<affects>total</affects>
-					<notes>Useful information regarding the object or place</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Retrocognitive Flashbacks_3</name>
-					<cost type="points">0</cost>
-					<affects>total</affects>
-					<notes>Receive visions easier</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Retrocognitive Flashbacks_4</name>
-					<cost type="points">0</cost>
-					<affects>total</affects>
-					<notes>Clear and straightforward visions</notes>
-				</modifier>
-				<reference>PSI38</reference>
-				<notes>Divination ability. You receive flashes of events from the past.</notes>
+				<levels>1</levels>
+				<points_per_level>22</points_per_level>
+				<reference>PSI45</reference>
+				<notes>Probability alteration ability.  You can alter the weather.</notes>
 				<categories>
-					<category>Divination</category>
-					<category>ESP</category>
+					<category>Probability Alteration</category>
 					<category>Psionics</category>
 				</categories>
-				<prereq_list all="yes">
-					<advantage_prereq has="yes">
-						<name compare="is">Retrocognition</name>
-						<notes compare="contains">_</notes>
-					</advantage_prereq>
-				</prereq_list>
 			</advantage>
 			<advantage version="3">
-				<name>Signature Sniffer</name>
+				<name>Wild Talent</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>20</points_per_level>
+				<modifier version="1" enabled="no">
+					<name>Retention</name>
+					<reference>B99</reference>
+					<cost type="percentage">25</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Emergencies Only</name>
+					<reference>B100</reference>
+					<cost type="percentage">-30</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Focused</name>
+					<reference>B99</reference>
+					<cost type="percentage">-20</cost>
+					<affects>total</affects>
+					<notes>@Type: Mental, Physical, Magical or Chi@</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Wild Ability</name>
+					<reference>P90</reference>
+					<cost type="percentage">50</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>External</name>
+					<reference>P90</reference>
+					<cost type="percentage">-20</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1">
+					<name>Probability Alteration</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI46</reference>
+				<categories>
+					<category>Probability Alteration</category>
+					<category>Psionics</category>
+				</categories>
+			</advantage>
+		</advantage_container>
+		<advantage_container version="3" open="no">
+			<name>Psychic Healing</name>
+			<reference>PSI46</reference>
+			<categories>
+				<category>Psionics</category>
+				<category>Psychic Healing</category>
+			</categories>
+			<advantage version="3">
+				<name>Aura Reading</name>
 				<type>Mental</type>
 				<modifier version="1" enabled="no">
-					<name>Signature Sniffer_1</name>
+					<name>Aura Reading_1</name>
 					<cost type="points">4</cost>
 					<affects>total</affects>
-					<notes>Rough estimate of time</notes>
+					<notes>8 hours</notes>
 				</modifier>
 				<modifier version="1" enabled="no">
-					<name>Signature Sniffer_2</name>
-					<cost type="points">9</cost>
+					<name>Aura Reading_2</name>
+					<cost type="points">7</cost>
 					<affects>total</affects>
-					<notes>Improved estimate of time</notes>
+					<notes>1 hour</notes>
 				</modifier>
 				<modifier version="1" enabled="no">
-					<name>Signature Sniffer_3</name>
-					<cost type="points">18</cost>
+					<name>Aura Reading_3</name>
+					<cost type="points">13</cost>
 					<affects>total</affects>
-					<notes>Know time precisely</notes>
+					<notes>10 minutes</notes>
 				</modifier>
 				<modifier version="1" enabled="no">
-					<name>Signature Sniffer_4</name>
-					<cost type="points">28</cost>
+					<name>Aura Reading_4</name>
+					<cost type="points">16</cost>
 					<affects>total</affects>
-					<notes>Know time precisely</notes>
-				</modifier>
-				<reference>PSI38</reference>
-				<notes>Divination ability. You can detect psychic residue.</notes>
-				<categories>
-					<category>Divination</category>
-					<category>ESP</category>
-					<category>Psionics</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Signature Sniffer (Have Psi Sense)</name>
-				<type>Mental</type>
-				<base_points>5</base_points>
-				<modifier version="1" enabled="no">
-					<name>Signature Sniffer_1</name>
-					<cost type="points">0</cost>
-					<affects>total</affects>
-					<notes>Rough estimate of time</notes>
+					<notes>1 minute</notes>
 				</modifier>
 				<modifier version="1" enabled="no">
-					<name>Signature Sniffer_2</name>
-					<cost type="points">0</cost>
+					<name>Aura Reading_5</name>
+					<cost type="points">22</cost>
 					<affects>total</affects>
-					<notes>Improved estimate of time</notes>
+					<notes>1 second</notes>
 				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Signature Sniffer_3</name>
-					<cost type="points">0</cost>
-					<affects>total</affects>
-					<notes>Know time precisely</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Signature Sniffer_4</name>
-					<cost type="points">0</cost>
-					<affects>total</affects>
-					<notes>Know time precisely</notes>
-				</modifier>
-				<reference>PSI38</reference>
-				<notes>Divination ability. You can detect psychic residue.</notes>
+				<reference>PSI46</reference>
+				<notes>Psychic healing ability. You understand the basic life force of human beings.</notes>
 				<categories>
-					<category>Divination</category>
-					<category>ESP</category>
 					<category>Psionics</category>
-				</categories>
-				<prereq_list all="no">
-					<advantage_prereq has="yes">
-						<name compare="is">Psi Sense</name>
-						<notes compare="contains">_</notes>
-					</advantage_prereq>
-				</prereq_list>
-			</advantage>
-			<advantage version="3">
-				<name>Visions (Aspected Dream)</name>
-				<type>Mental</type>
-				<base_points>1</base_points>
-				<reference>PSI42</reference>
-				<categories>
-					<category>Divination</category>
-					<category>ESP</category>
-					<category>Perk</category>
-					<category>Psionics</category>
+					<category>Psychic Healing</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Visions (Dream)</name>
-				<type>Mental</type>
-				<base_points>5</base_points>
-				<reference>PSI39</reference>
-				<notes>Divination ability. You receive visions while asleep.</notes>
-				<categories>
-					<category>Divination</category>
-					<category>ESP</category>
-					<category>Psionics</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Visions (Full)</name>
-				<type>Mental</type>
-				<base_points>20</base_points>
-				<reference>PSI39</reference>
-				<notes>Divination ability. Visions appear at appropriate times. </notes>
-				<categories>
-					<category>Divination</category>
-					<category>ESP</category>
-					<category>Psionics</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Visions (Overwhelming)</name>
-				<type>Mental</type>
-				<base_points>15</base_points>
-				<reference>PSI39</reference>
-				<notes>Divination ability. Powerful visions leave you reeling. </notes>
-				<categories>
-					<category>Divination</category>
-					<category>ESP</category>
-					<category>Psionics</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Visions (Second Sight)</name>
-				<type>Mental</type>
-				<base_points>5</base_points>
-				<reference>PSI39</reference>
-				<notes>Divination ability. You receive visions when encountering situations or people. </notes>
-				<categories>
-					<category>Divination</category>
-					<category>ESP</category>
-					<category>Psionics</category>
-				</categories>
-			</advantage>
-		</advantage_container>
-		<advantage version="3">
-			<name>Dowsing</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI42</reference>
-			<categories>
-				<category>ESP</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Remote Senses</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>ESP Talent</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>5</points_per_level>
-			<reference>PSI19</reference>
-			<categories>
-				<category>Divination</category>
-				<category>ESP</category>
-				<category>Power</category>
-				<category>Psionics</category>
-				<category>Remote Senses</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Common Sense</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Danger Sense</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Illuminated</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Oracle</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Psidar</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Psychic Hunches</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Racial Memory</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Seekersense</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Spirit Communication</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">True Sight (ESP)</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Combat Sense</name>
-				<specialization compare="is">Divination</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Prognostication</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Psi Sense</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Retrocognition</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Visions</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Awareness</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Clairvoyance</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Arching Shot</name>
-				<specialization compare="contains">ESP</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Blunting Armor</name>
-				<specialization compare="contains">ESP</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Far Shot</name>
-				<specialization compare="contains">ESP</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Forceful Blow</name>
-				<specialization compare="contains">ESP</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Guided Weapon</name>
-				<specialization compare="contains">ESP</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Impenetrable Armor</name>
-				<specialization compare="contains">ESP</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Padded Armor</name>
-				<specialization compare="contains">ESP</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Reinforce Armor</name>
-				<specialization compare="contains">ESP</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Supreme Control</name>
-				<specialization compare="contains">ESP</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Traumatic Blow</name>
-				<specialization compare="contains">ESP</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<prereq_list all="no">
-				<advantage_prereq has="no">
-					<name compare="is">Divination Talent</name>
-					<notes compare="is anything"></notes>
-					<level compare="at least">1</level>
-				</advantage_prereq>
-				<advantage_prereq has="no">
-					<name compare="is">Remote Senses Talent</name>
-					<notes compare="is anything"></notes>
-					<level compare="at least">1</level>
-				</advantage_prereq>
-			</prereq_list>
-		</advantage>
-		<advantage version="3">
-			<name>Exposition Sense</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI42</reference>
-			<categories>
-				<category>ESP</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Forecast</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI42</reference>
-			<categories>
-				<category>ESP</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Illuminated</name>
-			<type>Mental</type>
-			<base_points>15</base_points>
-			<modifier version="1">
-				<name>ESP</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI43</reference>
-			<categories>
-				<category>ESP</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Insider Glance (Armoury)</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI42</reference>
-			<categories>
-				<category>ESP</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Insider Glance (Electronics)</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI42</reference>
-			<categories>
-				<category>ESP</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Insider Glance (Mechanic)</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI42</reference>
-			<categories>
-				<category>ESP</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Insider Glance (Repair)</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI42</reference>
-			<categories>
-				<category>ESP</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Oracle</name>
-			<type>Mental</type>
-			<base_points>15</base_points>
-			<modifier version="1">
-				<name>ESP</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI43</reference>
-			<categories>
-				<category>ESP</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Protected Power (ESP)</name>
-			<type>Mental</type>
-			<base_points>5</base_points>
-			<modifier version="1">
-				<name>ESP</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI43</reference>
-			<categories>
-				<category>ESP</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Psi Sense</name>
-			<type>Mental</type>
-			<modifier version="1" enabled="no">
-				<name>Psi Sense_1</name>
-				<cost type="points">8</cost>
-				<affects>total</affects>
-				<notes>Vague sense</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Psi Sense_2</name>
-				<cost type="points">13</cost>
-				<affects>total</affects>
-				<notes>Gives direction of nearest psi use</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Psi Sense_3</name>
-				<cost type="points">22</cost>
-				<affects>total</affects>
-				<notes>Direction and distance to nearest psi usage</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Psi Sense_4</name>
-				<cost type="points">32</cost>
-				<affects>total</affects>
-				<notes>Direction, distance, and ability of nearest psi usage</notes>
-			</modifier>
-			<reference>PSI41</reference>
-			<notes>Divination ability. You can sense nearby psionic activity. </notes>
-			<categories>
-				<category>ESP</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Psidar</name>
-			<type>Mental</type>
-			<modifier version="1" enabled="no">
-				<name>Psidar_1</name>
-				<cost type="points">9</cost>
-				<affects>total</affects>
-				<notes>Vague sense</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Psidar_2</name>
-				<cost type="points">14</cost>
-				<affects>total</affects>
-				<notes>Gives direction of nearest psi</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Psidar_3</name>
-				<cost type="points">19</cost>
-				<affects>total</affects>
-				<notes>Direction and distance to nearest psi</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Psidar_4</name>
-				<cost type="points">29</cost>
-				<affects>total</affects>
-				<notes>Direction, distance, and ability known by nearest psi</notes>
-			</modifier>
-			<reference>PSI41</reference>
-			<notes>Divination ability. You can sense nearby psis.</notes>
-			<categories>
-				<category>ESP</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Psychic Hunches</name>
-			<type>Mental</type>
-			<modifier version="1" enabled="no">
-				<name>Psychic Hunches_1</name>
-				<cost type="points">14</cost>
-				<affects>total</affects>
-				<reference>B63</reference>
-				<notes>As intuition, p. B63</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Psychic Hunches_2</name>
-				<cost type="points">29</cost>
-				<affects>total</affects>
-				<notes>On a success, GM will tell you the best option.</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Psychic Hunches_3</name>
-				<cost type="points">36</cost>
-				<affects>total</affects>
-				<notes>Best choice and how to approach it on a success. </notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Psychic Hunches_4</name>
-				<cost type="points">51</cost>
-				<affects>total</affects>
-				<notes>Passive ability.</notes>
-			</modifier>
-			<reference>PSI42</reference>
-			<notes>Divination ability. You have a knack for guessing correctly.</notes>
-			<categories>
-				<category>ESP</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Racial Memory</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<base_points>-10</base_points>
-			<points_per_level>25</points_per_level>
-			<modifier version="1">
-				<name>ESP</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI43</reference>
-			<categories>
-				<category>ESP</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage_container version="3" open="yes">
-			<name>Remote Senses</name>
-			<reference>PSI39</reference>
-			<notes>Branch of ESP</notes>
-			<categories>
-				<category>ESP</category>
-				<category>Psionics</category>
-				<category>Remote Senses</category>
-			</categories>
-			<advantage version="3">
-				<name>Awareness</name>
-				<type>Mental</type>
-				<levels>1</levels>
-				<base_points>7</base_points>
-				<points_per_level>2</points_per_level>
-				<reference>PSI39</reference>
-				<notes>Remote senses ability. You have psychic awareness of your immediate vacinity. </notes>
-				<categories>
-					<category>ESP</category>
-					<category>Psionics</category>
-					<category>Remote Senses</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Clairaudience (Have Clairvoyance)</name>
-				<type>Mental</type>
-				<levels>1</levels>
-				<base_points>5</base_points>
-				<reference>PSI40</reference>
-				<notes>Remote senses ability. You can project your sense of hearing away from your body.</notes>
-				<categories>
-					<category>ESP</category>
-					<category>Psionics</category>
-					<category>Remote Senses</category>
-				</categories>
-				<prereq_list all="yes">
-					<advantage_prereq has="yes">
-						<name compare="is">Clairvoyance</name>
-						<notes compare="is anything"></notes>
-						<level compare="at least">1</level>
-					</advantage_prereq>
-				</prereq_list>
-			</advantage>
-			<advantage version="3">
-				<name>Clairaudience</name>
-				<type>Mental</type>
-				<levels>1</levels>
-				<base_points>8</base_points>
-				<points_per_level>5</points_per_level>
-				<reference>PSI40</reference>
-				<notes>Remote senses ability. You can project your sense of hearing away from your body.</notes>
-				<categories>
-					<category>ESP</category>
-					<category>Psionics</category>
-					<category>Remote Senses</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Clairvoyance</name>
-				<type>Mental</type>
-				<levels>1</levels>
-				<base_points>8</base_points>
-				<points_per_level>5</points_per_level>
-				<reference>PSI40</reference>
-				<notes>Remote senses ability. You can project your sense of sight away from your body.</notes>
-				<categories>
-					<category>ESP</category>
-					<category>Psionics</category>
-					<category>Remote Senses</category>
-				</categories>
-			</advantage>
-		</advantage_container>
-		<advantage version="3">
-			<name>Seekersense</name>
-			<type>Mental</type>
-			<modifier version="1" enabled="no">
-				<name>Seekersense_1</name>
-				<cost type="points">7</cost>
-				<affects>total</affects>
-				<reference>B550</reference>
-				<notes>Use range penalties p. B550</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Seekersense_2</name>
-				<cost type="points">13</cost>
-				<affects>total</affects>
-				<notes>You can search for similar people or items. </notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Seekersense_3</name>
-				<cost type="points">18</cost>
-				<affects>total</affects>
-				<reference>B241</reference>
-				<notes>Use long-distance modifiers p. B241</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Seekersense_4</name>
-				<cost type="points">29</cost>
-				<affects>total</affects>
-				<notes>Fast seekersense (1 second)</notes>
-			</modifier>
-			<reference>PSI42</reference>
-			<notes>Divination ability. You can home in on anyone or anything under certain conditions.</notes>
-			<categories>
-				<category>ESP</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Spirit Communication</name>
-			<type>Mental</type>
-			<modifier version="1" enabled="no">
-				<name>Spirit Communication_1</name>
-				<cost type="points">8</cost>
-				<affects>total</affects>
-				<notes>Must share a language</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Spirit Communication_2</name>
-				<cost type="points">13</cost>
-				<affects>total</affects>
-				<notes>Sharing a language not necessary</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Spirit Communication_3</name>
-				<cost type="points">18</cost>
-				<affects>total</affects>
-				<notes>Can see and speak with spirits.</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Psychic Hunches_4</name>
-				<cost type="points">28</cost>
-				<affects>total</affects>
-				<notes>Others can see the spirits you're speaking with.</notes>
-			</modifier>
-			<reference>PSI43</reference>
-			<notes>Divination ability. You can speak with spirits. </notes>
-			<categories>
-				<category>ESP</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>True Sight (ESP)</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<base_points>11</base_points>
-			<points_per_level>4</points_per_level>
-			<reference>PSI43</reference>
-			<notes>Divination ability. As True sight anti-psi ability p. Psi25</notes>
-			<categories>
-				<category>ESP</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-	</advantage_container>
-	<advantage_container version="3" open="yes">
-		<name>Probability Alteration</name>
-		<reference>PSI43</reference>
-		<categories>
-			<category>Probability Alteration</category>
-			<category>Psionics</category>
-		</categories>
-		<advantage version="3">
-			<name>Adjustment</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<base_points>6</base_points>
-			<points_per_level>4</points_per_level>
-			<reference>PSI44</reference>
-			<notes>Probability alteration ability.  You can affect the outcome of events. </notes>
-			<categories>
-				<category>Probability Alteration</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Coincidence</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>27</points_per_level>
-			<reference>PSI44</reference>
-			<notes>Probability alteration ability.  You can arrange coincidences.</notes>
-			<categories>
-				<category>Probability Alteration</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Combat Sense</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>24</points_per_level>
-			<reference>PSI45</reference>
-			<notes>Probability alteration ability. You can avoid attacks through luck.</notes>
-			<categories>
-				<category>Probability Alteration</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Curse</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<base_points>20</base_points>
-			<points_per_level>2</points_per_level>
-			<reference>PSI45</reference>
-			<notes>Probability alteration ability.  You can negatively affect someone's fate. </notes>
-			<categories>
-				<category>Probability Alteration</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Good Neighbor</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI44</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Probability Alteration</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Karma Bank</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI44</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Probability Alteration</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Loaded Dice</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI44</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Probability Alteration</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Lucky Break</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI44</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Probability Alteration</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Misfire Master</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI44</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Probability Alteration</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Moneyclip Magnet</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI44</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Probability Alteration</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Probability Alteration Talent</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>5</points_per_level>
-			<reference>PSI19</reference>
-			<categories>
-				<category>Power</category>
-				<category>Probability Alteration</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Adjustment</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Arching Shot</name>
-				<specialization compare="contains">Probability Alteration</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Bank Shot</name>
-				<specialization compare="contains">Probability Alteration</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Blunting Armor</name>
-				<specialization compare="contains">Probability Alteration</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Coincidence</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Crushing Strike</name>
-				<specialization compare="contains">Probability Alteration</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Curse</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Combat Sense</name>
-				<specialization compare="is anything">Probability Alteration</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Expand Armor</name>
-				<specialization compare="contains">Probability Alteration</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Homing Weapon</name>
-				<specialization compare="contains">Probability Alteration</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Impenetrable Armor</name>
-				<specialization compare="contains">Probability Alteration</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Padded Armor</name>
-				<specialization compare="contains">Probability Alteration</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Reinforce Armor</name>
-				<specialization compare="contains">Probability Alteration</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Second Chance</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Weather Control</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Widen Shield</name>
-				<specialization compare="contains">Probability Alteration</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-		</advantage>
-		<advantage version="3">
-			<name>Protected Power (Probability Alteration)</name>
-			<type>Mental</type>
-			<base_points>5</base_points>
-			<modifier version="1">
-				<name>Astral Projection</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI46</reference>
-			<categories>
-				<category>Probability Alteration</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Second Chance</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>12</points_per_level>
-			<reference>PSI45</reference>
-			<notes>Probability alteration ability.  You can reroll an action.</notes>
-			<categories>
-				<category>Probability Alteration</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Shopper's Blessing</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI44</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Probability Alteration</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Weather Control</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>22</points_per_level>
-			<reference>PSI45</reference>
-			<notes>Probability alteration ability.  You can alter the weather.</notes>
-			<categories>
-				<category>Probability Alteration</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Wild Talent</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>20</points_per_level>
-			<modifier version="1" enabled="no">
-				<name>Retention</name>
-				<cost type="percentage">25</cost>
-				<affects>total</affects>
-				<reference>B99</reference>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Emergencies Only</name>
-				<cost type="percentage">-30</cost>
-				<affects>total</affects>
-				<reference>B100</reference>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Focused</name>
-				<cost type="percentage">-20</cost>
-				<affects>total</affects>
-				<reference>B99</reference>
-				<notes>@Type: Mental, Physical, Magical or Chi@</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Wild Ability</name>
-				<cost type="percentage">50</cost>
-				<affects>total</affects>
-				<reference>P90</reference>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>External</name>
-				<cost type="percentage">-20</cost>
-				<affects>total</affects>
-				<reference>P90</reference>
-			</modifier>
-			<modifier version="1">
-				<name>Probability Alteration</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI46</reference>
-			<categories>
-				<category>Probability Alteration</category>
-				<category>Psionics</category>
-			</categories>
-		</advantage>
-	</advantage_container>
-	<advantage_container version="3" open="yes">
-		<name>Psychic Healing</name>
-		<reference>PSI46</reference>
-		<categories>
-			<category>Psionics</category>
-			<category>Psychic Healing</category>
-		</categories>
-		<advantage version="3">
-			<name>Aura Reading</name>
-			<type>Mental</type>
-			<modifier version="1" enabled="no">
-				<name>Aura Reading_1</name>
-				<cost type="points">4</cost>
-				<affects>total</affects>
-				<notes>8 hours</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Aura Reading_2</name>
-				<cost type="points">7</cost>
-				<affects>total</affects>
-				<notes>1 hour</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Aura Reading_3</name>
-				<cost type="points">13</cost>
-				<affects>total</affects>
-				<notes>10 minutes</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Aura Reading_4</name>
-				<cost type="points">16</cost>
-				<affects>total</affects>
-				<notes>1 minute</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Aura Reading_5</name>
-				<cost type="points">22</cost>
-				<affects>total</affects>
-				<notes>1 second</notes>
-			</modifier>
-			<reference>PSI46</reference>
-			<notes>Psychic healing ability. You understand the basic life force of human beings.</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Cure</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<base_points>12</base_points>
-			<points_per_level>6</points_per_level>
-			<reference>PSI46</reference>
-			<notes>Psychic healing ability. You can restore the health of others.</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Cure Disease</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>6</points_per_level>
-			<reference>PSI47</reference>
-			<notes>Psychic healing ability. You cure diseases of others.</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Cure Injury</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<base_points>6</base_points>
-			<points_per_level>6</points_per_level>
-			<reference>PSI47</reference>
-			<notes>Psychic healing ability. You can heal injuries of others. </notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Disease Shield</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<base_points>13</base_points>
-			<points_per_level>2</points_per_level>
-			<reference>PSI48</reference>
-			<notes>Psychic healing ability. You can temporarily protect someone from diseases. </notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Empathy</name>
-			<type>Mental</type>
-			<base_points>15</base_points>
-			<modifier version="1">
-				<name>Psychic Healing</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI49</reference>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Healing Bond</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI48</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Immunity, Disease</name>
-			<type>Mental</type>
-			<base_points>10</base_points>
-			<modifier version="1">
-				<name>Psychic Healing</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI49</reference>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Immunity, Ingested Poison</name>
-			<type>Mental</type>
-			<base_points>10</base_points>
-			<modifier version="1">
-				<name>Psychic Healing</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI49</reference>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Immunity, Poison</name>
-			<type>Mental</type>
-			<base_points>15</base_points>
-			<modifier version="1">
-				<name>Psychic Healing</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI49</reference>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Immunity, Sickness</name>
-			<type>Mental</type>
-			<base_points>15</base_points>
-			<modifier version="1">
-				<name>Psychic Healing</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI49</reference>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Life Extension</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<base_points>-3</base_points>
-			<points_per_level>12</points_per_level>
-			<reference>PSI48</reference>
-			<notes>Psychic healing ability. You can slow the aging process within your body.</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Life Support</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI48</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Major Disease Resistance</name>
-			<type>Mental</type>
-			<base_points>5</base_points>
-			<modifier version="1">
-				<name>Psychic Healing</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI49</reference>
-			<notes>+8 to resist disease</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Major Ingested Poison Resistance</name>
-			<type>Mental</type>
-			<base_points>3</base_points>
-			<modifier version="1">
-				<name>Psychic Healing</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI49</reference>
-			<notes>+8 to resist ingested poisons</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Major Poison Resistance</name>
-			<type>Mental</type>
-			<base_points>7</base_points>
-			<modifier version="1">
-				<name>Psychic Healing</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI49</reference>
-			<notes>+8 to resist poison</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Major Sickness Resistance</name>
-			<type>Mental</type>
-			<base_points>7</base_points>
-			<modifier version="1">
-				<name>Psychic Healing</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI49</reference>
-			<notes>+8 to resist sicknesses</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Metabolism Control</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>5</points_per_level>
-			<modifier version="1">
-				<name>Psychic Healing</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI49</reference>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Minor Disease Resistance</name>
-			<type>Mental</type>
-			<base_points>3</base_points>
-			<modifier version="1">
-				<name>Psychic Healing</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI49</reference>
-			<notes>+3 to resist disease</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Minor Ingested Poison Resistance</name>
-			<type>Mental</type>
-			<base_points>3</base_points>
-			<modifier version="1">
-				<name>Psychic Healing</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI49</reference>
-			<notes>+3 to resist ingested poisons</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Minor Poison Resistance</name>
-			<type>Mental</type>
-			<base_points>5</base_points>
-			<modifier version="1">
-				<name>Psychic Healing</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI49</reference>
-			<notes>+3 to resist poison</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Minor Sickness Resistance</name>
-			<type>Mental</type>
-			<base_points>5</base_points>
-			<modifier version="1">
-				<name>Psychic Healing</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI49</reference>
-			<notes>+3 to resist sicknesses</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Natural Doctor</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI48</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Pharmaceutical Probe</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI48</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Postmortem</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI48</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Protected Power (Psychic Healing)</name>
-			<type>Mental</type>
-			<base_points>15</base_points>
-			<modifier version="1">
-				<name>Psychic Healing</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI49</reference>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Psychic Healing Talent</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>5</points_per_level>
-			<reference>PSI19</reference>
-			<categories>
-				<category>Power</category>
-				<category>Psychic Healing</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Aura Reading</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Cure</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Disease Shield</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Life Extension</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Sleep (Psychic Healing)</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Empathy</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Metabolism Control</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Continuing Attack</name>
-				<specialization compare="contains">Psychic Healing</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Crippling Blow</name>
-				<specialization compare="contains">Psychic Healing</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Drugged Weapon</name>
-				<specialization compare="contains">Psychic Healing</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Energizing Defense</name>
-				<specialization compare="contains">Psychic Healing</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Healthful Armor</name>
-				<specialization compare="contains">Psychic Healing</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Resilient Armor</name>
-				<specialization compare="contains">Psychic Healing</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Restorative Armor</name>
-				<specialization compare="contains">Psychic Healing</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Sovereign Armor</name>
-				<specialization compare="contains">Psychic Healing</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Sudden Death</name>
-				<specialization compare="contains">Psychic Healing</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Toxic Strike</name>
-				<specialization compare="contains">Psychic Healing</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Withering Strike</name>
-				<specialization compare="contains">Psychic Healing</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-		</advantage>
-		<advantage version="3">
-			<name>Psychic Surgery</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI48</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Regeneration</name>
-			<type>Mental</type>
-			<modifier version="1">
-				<name>Psychic Healing</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Slow</name>
-				<cost type="points">10</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Regular</name>
-				<cost type="points">25</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Fast</name>
-				<cost type="points">50</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI49</reference>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Regrowth</name>
-			<type>Mental</type>
-			<base_points>40</base_points>
-			<modifier version="1">
-				<name>Psychic Healing</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI49</reference>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Sleep (Psychic Healing)</name>
-			<type>Mental</type>
-			<modifier version="1" enabled="no">
-				<name>Sleep_1</name>
-				<cost type="points">25</cost>
-				<affects>total</affects>
-				<notes>Skin-to-skin contact.</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Sleep_2</name>
-				<cost type="points">28</cost>
-				<affects>total</affects>
-				<notes>Any touch will suffice.</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Sleep_3</name>
-				<cost type="points">31</cost>
-				<affects>total</affects>
-				<notes>Can use sleep at range; -1 penalty/yard distance</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Sleep_4</name>
-				<cost type="points">36</cost>
-				<affects>total</affects>
-				<reference>B550</reference>
-				<notes>Use range penalties p. B550</notes>
-			</modifier>
-			<reference>PSI49</reference>
-			<notes>Psychic healing ability. You safely put someone to sleep.</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Soothing Touch</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI48</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychic Healing</category>
-			</categories>
-		</advantage>
-	</advantage_container>
-	<advantage_container version="3" open="yes">
-		<name>Psychic Vampirism</name>
-		<reference>PSI49</reference>
-		<categories>
-			<category>Psionics</category>
-			<category>Psychic Vampirism</category>
-		</categories>
-		<advantage version="3">
-			<name>Blood Healing</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI51</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychic Vampirism</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Controllable Lifebane</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI51</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychic Vampirism</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Detect Life</name>
-			<type>Mental</type>
-			<base_points>30</base_points>
-			<modifier version="1">
-				<name>Psychic Vampirism</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI52</reference>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Vampirism</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Drain DX</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<base_points>22</base_points>
-			<points_per_level>2</points_per_level>
-			<reference>PSI50</reference>
-			<notes>Psychic vampirism ability. Reduce someone's DX.</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Vampirism</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Drain Emotion</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<base_points>5</base_points>
-			<points_per_level>5</points_per_level>
-			<reference>PSI50</reference>
-			<notes>Psychic vampirism ability. Reduce someone's HT.</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Vampirism</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Drain HT</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<base_points>22</base_points>
-			<points_per_level>2</points_per_level>
-			<reference>PSI50</reference>
-			<notes>Psychic vampirism ability. Reduce someone's HT.</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Vampirism</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Drain IQ</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<base_points>22</base_points>
-			<points_per_level>2</points_per_level>
-			<reference>PSI50</reference>
-			<notes>Psychic vampirism ability. Reduce someone's IQ.</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Vampirism</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Drain ST</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<base_points>22</base_points>
-			<points_per_level>2</points_per_level>
-			<reference>PSI50</reference>
-			<notes>Psychic vampirism ability. Reduce someone's ST.</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Vampirism</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Invigoration</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI51</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychic Vampirism</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Pleasant Theft</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI51</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychic Vampirism</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Poison Charm</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI51</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychic Vampirism</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Protected Power (Psychic Vampirism)</name>
-			<type>Mental</type>
-			<base_points>5</base_points>
-			<modifier version="1">
-				<name>Psychic Vampirism</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI52</reference>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Vampirism</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Psychic Vampirism Talent</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>5</points_per_level>
-			<reference>PSI19</reference>
-			<categories>
-				<category>Power</category>
-				<category>Psychic Vampirism</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Detect Life</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Drain DX</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Drain Emotion</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Drain HT</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Drain IQ</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Drain ST</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Steal Dreams</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Steal Energy</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Steal Life</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Steal Power</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Annihilating Weapon</name>
-				<specialization compare="contains">Psychic Vampirism</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Chilling Strike</name>
-				<specialization compare="contains">Psychic Vampirism</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Corrosive Strike</name>
-				<specialization compare="contains">Psychic Vampirism</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Energizing Defense</name>
-				<specialization compare="contains">Psychic Vampirism</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Envenomed Weapon</name>
-				<specialization compare="contains">Psychic Vampirism</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Sudden Death</name>
-				<specialization compare="contains">Psychic Vampirism</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Toxic Strike</name>
-				<specialization compare="contains">Psychic Vampirism</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Traumatic Blow</name>
-				<specialization compare="contains">Psychic Vampirism</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Vampiric Weapon</name>
-				<specialization compare="contains">Psychic Vampirism</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Vengeful Defense</name>
-				<specialization compare="contains">Psychic Vampirism</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Withering Strike</name>
-				<specialization compare="contains">Psychic Vampirism</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-		</advantage>
-		<advantage version="3">
-			<name>Schadenfreude</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI51</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychic Vampirism</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Social Vampire</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI51</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychic Vampirism</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Steal Dreams</name>
-			<type>Mental</type>
-			<modifier version="1" enabled="no">
-				<name>Steal Dreams_1</name>
-				<cost type="points">23</cost>
-				<affects>total</affects>
-				<notes>Skin-to-skin contact</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Steal Dreams_2</name>
-				<cost type="points">31</cost>
-				<affects>total</affects>
-				<notes>Any touch will suffice</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Steal Dreams_3</name>
-				<cost type="points">40</cost>
-				<affects>total</affects>
-				<notes>Steal dreams at range; -1 penalty/yard distance. </notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Steal Dreams_4</name>
-				<cost type="points">0</cost>
-				<affects>total</affects>
-				<reference>B550</reference>
-				<notes>Use range penalties p. B550</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Steal Dreams_5</name>
-				<cost type="points">67</cost>
-				<affects>total</affects>
-				<reference>B241</reference>
-				<notes>Use long-distance modifiers p. B241</notes>
-			</modifier>
-			<reference>PSI50</reference>
-			<notes>Psychic vampirism ability. Rob someone of their dreams. </notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Vampirism</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Steal Energy</name>
-			<type>Mental</type>
-			<modifier version="1" enabled="no">
-				<name>Steal Energy_1</name>
-				<cost type="points">32</cost>
-				<affects>total</affects>
-				<notes>30 seconds</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Steal Energy_2</name>
-				<cost type="points">34</cost>
-				<affects>total</affects>
-				<notes>15 seconds</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Steal Energy_3</name>
-				<cost type="points">37</cost>
-				<affects>total</affects>
-				<notes>8 seconds</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Steal Energy_4</name>
-				<cost type="points">39</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Steal Energy_5</name>
-				<cost type="points">42</cost>
-				<affects>total</affects>
-				<notes>4 seconds</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Steal Energy_6</name>
-				<cost type="points">44</cost>
-				<affects>total</affects>
-				<notes>1 second</notes>
-			</modifier>
-			<reference>PSI51</reference>
-			<notes>Psychic vampirism ability. Rob someone of their FP to replenish your own. </notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Vampirism</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Steal Life</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<base_points>21</base_points>
-			<points_per_level>4</points_per_level>
-			<reference>PSI52</reference>
-			<notes>Psychic vampirism ability. Rob someone of their HP to replenish your own.</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Vampirism</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Steal Power</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<base_points>45</base_points>
-			<points_per_level>10</points_per_level>
-			<reference>PSI52</reference>
-			<notes>Psychic vampirism ability. Steal someone's psi abilities. </notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychic Vampirism</category>
-			</categories>
-		</advantage>
-	</advantage_container>
-	<advantage_container version="3" open="yes">
-		<name>Psychokinesis</name>
-		<reference>PSI53</reference>
-		<categories>
-			<category>Psionics</category>
-			<category>Psychokinesis</category>
-		</categories>
-		<advantage version="3">
-			<name>Aerokinesis</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI56</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychokinesis</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Chill Factor</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI56</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychokinesis</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Cryokinesis</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>13</points_per_level>
-			<reference>PSI55</reference>
-			<notes>Telekinesis ability. You can lower temperatures.</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychokinesis</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Extra ST without HP</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>8</points_per_level>
-			<modifier version="1">
-				<name>Psychokinesis</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI57</reference>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychokinesis</category>
-				<category>Telekinesis</category>
-			</categories>
-			<attribute_bonus>
-				<attribute>st</attribute>
-				<amount per_level="yes">1</amount>
-			</attribute_bonus>
-			<attribute_bonus>
-				<attribute>hp</attribute>
-				<amount per_level="yes">-1</amount>
-			</attribute_bonus>
-		</advantage>
-		<advantage version="3">
-			<name>Gecko Grip</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI56</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychokinesis</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Hydrokinesis</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI56</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychokinesis</category>
-				<category>Telekinesis</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Ignition</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI56</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychokinesis</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>PK Shield</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>4</points_per_level>
-			<reference>PSI56</reference>
-			<notes>Telekinesis ability. You can resist or deflect incoming physical attacks. </notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychokinesis</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Protected Power (Psychokinesis)</name>
-			<type>Mental</type>
-			<base_points>5</base_points>
-			<modifier version="1">
-				<name>Psychokinesis</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI57</reference>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychokinesis</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Psychokinesis Talent</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>5</points_per_level>
-			<reference>PSI19</reference>
-			<categories>
-				<category>Power</category>
-				<category>Psychokinesis</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">TK Grab</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">TK Crush</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">TK Bullet</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Levitation</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Telekinetic Control</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Pyrokinesis</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">PK Shield</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Cryokinesis</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Blunting Armor</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Burning Strike</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Chilling Strike</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Crushing Strike</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Cutting Strike</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Dancing Shield</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Dancing Weapon</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Expand Armor</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Far Shot</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Forceful Blow</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Guided Weapon</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Impaling Strike</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Impenetrable Armor</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Incendiary Weapon</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Lighten Armor</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Padded Armor</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Piercing Strike</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Project Blow</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Reinforce Armor</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Rigid Armor</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Telescoping Weapon</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Traumatic Blow</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Widen Shield</name>
-				<specialization compare="contains">Psychokinesis</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<prereq_list all="yes">
-				<advantage_prereq has="no">
-					<name compare="is">Telekinesis Talent</name>
-					<notes compare="is anything"></notes>
-					<level compare="at least">1</level>
-				</advantage_prereq>
-			</prereq_list>
-		</advantage>
-		<advantage version="3">
-			<name>Pyrokinesis</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>14</points_per_level>
-			<reference>PSI56</reference>
-			<notes>Telekinesis ability. You can increase temperatures.</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychokinesis</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Small-Scale TK</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI56</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychokinesis</category>
-				<category>Telekinesis</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Strong Blade</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI56</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychokinesis</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Super Jump</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>10</points_per_level>
-			<modifier version="1">
-				<name>Psychokinesis</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI57</reference>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychokinesis</category>
-				<category>Telekinesis</category>
-			</categories>
-			<attribute_bonus>
-				<attribute>st</attribute>
-				<amount per_level="yes">1</amount>
-			</attribute_bonus>
-		</advantage>
-		<advantage_container version="3" open="yes">
-			<name>Telekinesis</name>
-			<reference>PSI53</reference>
-			<notes>Branch of psychokinesis</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychokinesis</category>
-				<category>Telekinesis</category>
-			</categories>
-			<advantage version="3">
-				<name>Levitation</name>
+				<name>Cure</name>
 				<type>Mental</type>
 				<levels>1</levels>
 				<base_points>12</base_points>
+				<points_per_level>6</points_per_level>
+				<reference>PSI46</reference>
+				<notes>Psychic healing ability. You can restore the health of others.</notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Healing</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Cure Disease</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>6</points_per_level>
+				<reference>PSI47</reference>
+				<notes>Psychic healing ability. You cure diseases of others.</notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Healing</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Cure Injury</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<base_points>6</base_points>
+				<points_per_level>6</points_per_level>
+				<reference>PSI47</reference>
+				<notes>Psychic healing ability. You can heal injuries of others. </notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Healing</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Disease Shield</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<base_points>13</base_points>
 				<points_per_level>2</points_per_level>
-				<reference>PSI55</reference>
-				<notes>Telekinesis ability. You can pick yourself up and fly.</notes>
+				<reference>PSI48</reference>
+				<notes>Psychic healing ability. You can temporarily protect someone from diseases. </notes>
 				<categories>
 					<category>Psionics</category>
-					<category>Psychokinesis</category>
-					<category>Telekinesis</category>
+					<category>Psychic Healing</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Telekinetic Control</name>
+				<name>Empathy</name>
+				<type>Mental</type>
+				<base_points>15</base_points>
+				<modifier version="1">
+					<name>Psychic Healing</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI49</reference>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Healing</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Healing Bond</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI48</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychic Healing</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Immunity, Disease</name>
+				<type>Mental</type>
+				<base_points>10</base_points>
+				<modifier version="1">
+					<name>Psychic Healing</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI49</reference>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Healing</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Immunity, Ingested Poison</name>
+				<type>Mental</type>
+				<base_points>10</base_points>
+				<modifier version="1">
+					<name>Psychic Healing</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI49</reference>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Healing</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Immunity, Poison</name>
+				<type>Mental</type>
+				<base_points>15</base_points>
+				<modifier version="1">
+					<name>Psychic Healing</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI49</reference>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Healing</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Immunity, Sickness</name>
+				<type>Mental</type>
+				<base_points>15</base_points>
+				<modifier version="1">
+					<name>Psychic Healing</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI49</reference>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Healing</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Life Extension</name>
 				<type>Mental</type>
 				<levels>1</levels>
-				<points_per_level>8</points_per_level>
-				<reference>PSI54</reference>
-				<notes>Telekinesis ability. Unified telekinetic abilities.</notes>
+				<base_points>-3</base_points>
+				<points_per_level>12</points_per_level>
+				<reference>PSI48</reference>
+				<notes>Psychic healing ability. You can slow the aging process within your body.</notes>
 				<categories>
 					<category>Psionics</category>
-					<category>Psychokinesis</category>
-					<category>Telekinesis</category>
+					<category>Psychic Healing</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>TK Bullet</name>
+				<name>Life Support</name>
 				<type>Mental</type>
-				<levels>1</levels>
-				<points_per_level>5</points_per_level>
-				<ranged_weapon>
-					<damage type="pi" base="1d-1"/>
-					<usage>Bullet</usage>
-					<accuracy>3</accuracy>
-					<range>500/2000</range>
-					<rate_of_fire>1</rate_of_fire>
-					<recoil>1</recoil>
-					<default>
-						<type>DX</type>
-						<modifier>-4</modifier>
-					</default>
-					<default>
-						<type>Skill</type>
-						<name>Innate Attack</name>
-						<modifier>-2</modifier>
-					</default>
-					<default>
-						<type>Skill</type>
-						<name>Innate Attack</name>
-						<specialization>Projectile</specialization>
-						<modifier>0</modifier>
-					</default>
-				</ranged_weapon>
-				<ranged_weapon>
-					<damage type="pi+" base="1d-1"/>
-					<usage>Flat Edge</usage>
-					<accuracy>3</accuracy>
-					<range>500/2000</range>
-					<rate_of_fire>1</rate_of_fire>
-					<recoil>1</recoil>
-					<default>
-						<type>DX</type>
-						<modifier>-4</modifier>
-					</default>
-					<default>
-						<type>Skill</type>
-						<name>Innate Attack</name>
-						<modifier>-2</modifier>
-					</default>
-					<default>
-						<type>Skill</type>
-						<name>Innate Attack</name>
-						<specialization>Projectile</specialization>
-						<modifier>0</modifier>
-					</default>
-				</ranged_weapon>
-				<ranged_weapon>
-					<damage type="pi" base="1d-1" armor_divisor="2.0"/>
-					<usage>Sharp Edge</usage>
-					<accuracy>3</accuracy>
-					<range>500/2000</range>
-					<rate_of_fire>1</rate_of_fire>
-					<recoil>1</recoil>
-					<default>
-						<type>DX</type>
-						<modifier>-4</modifier>
-					</default>
-					<default>
-						<type>Skill</type>
-						<name>Innate Attack</name>
-						<modifier>-2</modifier>
-					</default>
-					<default>
-						<type>Skill</type>
-						<name>Innate Attack</name>
-						<specialization>Projectile</specialization>
-						<modifier>0</modifier>
-					</default>
-				</ranged_weapon>
-				<ranged_weapon>
-					<damage type="pi" base="1d-1"/>
-					<usage>Rapid Fire</usage>
-					<accuracy>3</accuracy>
-					<range>500/2000</range>
-					<rate_of_fire>7</rate_of_fire>
-					<recoil>1</recoil>
-					<default>
-						<type>DX</type>
-						<modifier>-4</modifier>
-					</default>
-					<default>
-						<type>Skill</type>
-						<name>Innate Attack</name>
-						<modifier>-2</modifier>
-					</default>
-					<default>
-						<type>Skill</type>
-						<name>Innate Attack</name>
-						<specialization>Projectile</specialization>
-						<modifier>0</modifier>
-					</default>
-				</ranged_weapon>
-				<ranged_weapon>
-					<damage type="pi" base="1d-2"/>
-					<usage>Silencer</usage>
-					<accuracy>3</accuracy>
-					<range>500/2000</range>
-					<rate_of_fire>1</rate_of_fire>
-					<recoil>1</recoil>
-					<default>
-						<type>DX</type>
-						<modifier>-4</modifier>
-					</default>
-					<default>
-						<type>Skill</type>
-						<name>Innate Attack</name>
-						<modifier>-2</modifier>
-					</default>
-					<default>
-						<type>Skill</type>
-						<name>Innate Attack</name>
-						<specialization>Projectile</specialization>
-						<modifier>0</modifier>
-					</default>
-				</ranged_weapon>
-				<reference>PSI53</reference>
-				<notes>Telekinesis ability. Throw stones at bullet-like speeds. </notes>
+				<base_points>1</base_points>
+				<reference>PSI48</reference>
 				<categories>
+					<category>Perk</category>
 					<category>Psionics</category>
-					<category>Psychokinesis</category>
-					<category>Telekinesis</category>
-				</categories>
-				<weapon_bonus>
-					<name compare="is">Innate Attack</name>
-					<specialization compare="is">Projectile</specialization>
-					<level compare="at least">1</level>
-					<category compare="is anything"></category>
-					<amount>1</amount>
-				</weapon_bonus>
-			</advantage>
-			<advantage version="3">
-				<name>TK Crush</name>
-				<type>Mental</type>
-				<levels>1</levels>
-				<points_per_level>5</points_per_level>
-				<ranged_weapon>
-					<damage type="pi/level" base="+1"/>
-					<usage>Gaze</usage>
-					<range>Within Sight</range>
-					<rate_of_fire>1</rate_of_fire>
-					<recoil>1</recoil>
-					<default>
-						<type>DX</type>
-						<modifier>-4</modifier>
-					</default>
-					<default>
-						<type>Skill</type>
-						<name>Innate Attack</name>
-						<modifier>-2</modifier>
-					</default>
-					<default>
-						<type>Skill</type>
-						<name>Innate Attack</name>
-						<specialization>Gaze</specialization>
-						<modifier>0</modifier>
-					</default>
-				</ranged_weapon>
-				<reference>PSI54</reference>
-				<notes>Telekinesis ability. Crush someone's internal organs by staring at them. </notes>
-				<categories>
-					<category>Psionics</category>
-					<category>Psychokinesis</category>
-					<category>Telekinesis</category>
+					<category>Psychic Healing</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>TK Grab</name>
-				<type>Mental</type>
-				<levels>1</levels>
-				<points_per_level>7</points_per_level>
-				<modifier version="1" enabled="no">
-					<name>Short Ranged (20 yards)</name>
-					<cost type="percentage">-43</cost>
-					<affects>total</affects>
-				</modifier>
-				<reference>PSI54</reference>
-				<notes>Telekinesis ability. Pick up and move objects from a distance. </notes>
-				<categories>
-					<category>Psionics</category>
-					<category>Psychokinesis</category>
-					<category>Telekinesis</category>
-				</categories>
-			</advantage>
-		</advantage_container>
-		<advantage version="3">
-			<name>Temperature Tolerance</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>1</points_per_level>
-			<modifier version="1">
-				<name>Psychokinesis</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI57</reference>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychokinesis</category>
-			</categories>
-			<attribute_bonus>
-				<attribute>st</attribute>
-				<amount per_level="yes">1</amount>
-			</attribute_bonus>
-		</advantage>
-		<advantage version="3">
-			<name>TK Tether</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI56</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychokinesis</category>
-				<category>Telekinesis</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Umbrella</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI56</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Psychokinesis</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Walk on Air</name>
-			<type>Mental</type>
-			<base_points>20</base_points>
-			<modifier version="1">
-				<name>Psychokinesis</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI57</reference>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychokinesis</category>
-				<category>Telekinesis</category>
-			</categories>
-			<attribute_bonus>
-				<attribute>st</attribute>
-				<amount per_level="yes">1</amount>
-			</attribute_bonus>
-		</advantage>
-		<advantage version="3">
-			<name>Walk on Liquid</name>
-			<type>Mental</type>
-			<base_points>15</base_points>
-			<modifier version="1">
-				<name>Psychokinesis</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI57</reference>
-			<categories>
-				<category>Psionics</category>
-				<category>Psychokinesis</category>
-				<category>Telekinesis</category>
-			</categories>
-			<attribute_bonus>
-				<attribute>st</attribute>
-				<amount per_level="yes">1</amount>
-			</attribute_bonus>
-		</advantage>
-	</advantage_container>
-	<advantage_container version="3" open="yes">
-		<name>Telepathy</name>
-		<reference>PSI57</reference>
-		<categories>
-			<category>Psionics</category>
-			<category>Telepathy</category>
-		</categories>
-		<advantage version="3">
-			<name>Avatar</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI63</reference>
-			<categories>
-				<category>Communication</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Telepathy</category>
-			</categories>
-		</advantage>
-		<advantage_container version="3" open="yes">
-			<name>Communication</name>
-			<reference>PSI57</reference>
-			<notes>Branch of Telepathy</notes>
-			<categories>
-				<category>Communication</category>
-				<category>Psionics</category>
-				<category>Telepathy</category>
-			</categories>
-			<advantage version="3">
-				<name>Borrow Skill</name>
-				<type>Mental</type>
-				<levels>1</levels>
-				<base_points>4</base_points>
-				<points_per_level>3</points_per_level>
-				<reference>PSI57</reference>
-				<notes>Communication ability. Borrow a skill or language from someone.</notes>
-				<categories>
-					<category>Communication</category>
-					<category>Psionics</category>
-					<category>Telepathy</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Emotion Sense</name>
-				<type>Mental</type>
-				<modifier version="1" enabled="no">
-					<name>Emotion Sense_1</name>
-					<cost type="points">3</cost>
-					<affects>total</affects>
-					<notes>Skin-to-skin contact</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Emotion Sense_2</name>
-					<cost type="points">9</cost>
-					<affects>total</affects>
-					<reference>B550</reference>
-					<notes>Use range penalties p. B550</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Emotion Sense_3</name>
-					<cost type="points">18</cost>
-					<affects>total</affects>
-					<reference>B241</reference>
-					<notes>Use long-distance modifiers p. B241</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Emotion Sense_4</name>
-					<cost type="points">20</cost>
-					<affects>total</affects>
-					<notes>No range penalties</notes>
-				</modifier>
-				<reference>PSI58</reference>
-				<notes>Communication ability. You get a brief flash of the emotions from the subject. </notes>
-				<categories>
-					<category>Communication</category>
-					<category>Psionics</category>
-					<category>Telepathy</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Telereceive</name>
-				<type>Mental</type>
-				<modifier version="1" enabled="no">
-					<name>Telereceive_1</name>
-					<cost type="points">21</cost>
-					<affects>total</affects>
-					<notes>Skin-to-skin contact</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telereceive_2</name>
-					<cost type="points">36</cost>
-					<affects>total</affects>
-					<notes>Any touch will suffice</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telereceive_3</name>
-					<cost type="points">42</cost>
-					<affects>total</affects>
-					<notes>Telereceive at range; -1 penalty/yard distance</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telereceive_4</name>
-					<cost type="points">45</cost>
-					<affects>total</affects>
-					<reference>B550</reference>
-					<notes>Use range penalties p. B550</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telereceive_5</name>
-					<cost type="points">60</cost>
-					<affects>total</affects>
-					<reference>B241</reference>
-					<notes>Use long-distance modifiers p. B241</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telereceive_6</name>
-					<cost type="points">75</cost>
-					<affects>total</affects>
-					<notes>No penalty for range</notes>
-				</modifier>
-				<reference>PSI58</reference>
-				<notes>Communication ability. You can read another person's thoughts. </notes>
-				<categories>
-					<category>Communication</category>
-					<category>Psionics</category>
-					<category>Telepathy</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Telereceive (Shallow)</name>
-				<type>Mental</type>
-				<modifier version="1" enabled="no">
-					<name>Telereceive_1</name>
-					<cost type="points">9</cost>
-					<affects>total</affects>
-					<notes>Skin-to-skin contact</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telereceive_2</name>
-					<cost type="points">18</cost>
-					<affects>total</affects>
-					<notes>Any touch will suffice</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telereceive_3</name>
-					<cost type="points">24</cost>
-					<affects>total</affects>
-					<notes>Telereceive at range; -1 penalty/yard distance</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telereceive_4</name>
-					<cost type="points">27</cost>
-					<affects>total</affects>
-					<reference>B550</reference>
-					<notes>Use range penalties p. B550</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telereceive_5</name>
-					<cost type="points">42</cost>
-					<affects>total</affects>
-					<reference>B241</reference>
-					<notes>Use long-distance modifiers p. B241</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telereceive_6</name>
-					<cost type="points">57</cost>
-					<affects>total</affects>
-					<notes>No penalty for range</notes>
-				</modifier>
-				<reference>PSI58</reference>
-				<notes>Communication ability. You can read another person's surface thoughts. </notes>
-				<categories>
-					<category>Communication</category>
-					<category>Psionics</category>
-					<category>Telepathy</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Telesend</name>
-				<type>Mental</type>
-				<modifier version="1" enabled="no">
-					<name>Telesend_1</name>
-					<cost type="points">9</cost>
-					<affects>total</affects>
-					<notes>Skin-to-skin contact</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telesend_2</name>
-					<cost type="points">18</cost>
-					<affects>total</affects>
-					<notes>Any touch will suffice</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telesend_3</name>
-					<cost type="points">21</cost>
-					<affects>total</affects>
-					<notes>Telesend at range; -1 penalty/yard distance</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telesend_4</name>
-					<cost type="points">24</cost>
-					<affects>total</affects>
-					<reference>B550</reference>
-					<notes>Use range penalties p. B550</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telesend_5</name>
-					<cost type="points">27</cost>
-					<affects>total</affects>
-					<reference>B241</reference>
-					<notes>Use long-distance modifiers p. B241</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telesend_6</name>
-					<cost type="points">42</cost>
-					<affects>total</affects>
-					<notes>No penalty for range</notes>
-				</modifier>
-				<reference>PSI60</reference>
-				<notes>Communication ability. You can read project your thoughts into another's mind. </notes>
-				<categories>
-					<category>Communication</category>
-					<category>Psionics</category>
-					<category>Telepathy</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Telespeak</name>
-				<type>Mental</type>
-				<modifier version="1" enabled="no">
-					<name>Telespeak_1</name>
-					<cost type="points">18</cost>
-					<affects>total</affects>
-					<notes>Skin-to-skin contact</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telespeak_2</name>
-					<cost type="points">30</cost>
-					<affects>total</affects>
-					<notes>Any touch will suffice</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telespeak_3</name>
-					<cost type="points">39</cost>
-					<affects>total</affects>
-					<notes>Telespeak at range; -1 penalty/yard distance</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telespeak_4</name>
-					<cost type="points">45</cost>
-					<affects>total</affects>
-					<reference>B550</reference>
-					<notes>Use range penalties p. B550</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telespeak_5</name>
-					<cost type="points">63</cost>
-					<affects>total</affects>
-					<reference>B241</reference>
-					<notes>Use long-distance modifiers p. B241</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telespeak_6</name>
-					<cost type="points">93</cost>
-					<affects>total</affects>
-					<notes>No penalty for range</notes>
-				</modifier>
-				<reference>PSI59</reference>
-				<notes>Communication ability. You can converse with someone telepathically. </notes>
-				<categories>
-					<category>Communication</category>
-					<category>Psionics</category>
-					<category>Telepathy</category>
-				</categories>
-			</advantage>
-		</advantage_container>
-		<advantage_container version="3" open="yes">
-			<name>Control</name>
-			<reference>PSI60</reference>
-			<notes>Branch of Telepathy</notes>
-			<categories>
-				<category>Control</category>
-				<category>Psionics</category>
-				<category>Telepathy</category>
-			</categories>
-			<advantage version="3">
-				<name>Aspect</name>
-				<type>Mental</type>
-				<levels>1</levels>
-				<points_per_level>4</points_per_level>
-				<reference>PSI61</reference>
-				<notes>Control ability.  You can alter how people feel about you. </notes>
-				<categories>
-					<category>Control</category>
-					<category>Psionics</category>
-					<category>Telepathy</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Emotion Control</name>
-				<type>Mental</type>
-				<modifier version="1" enabled="no">
-					<name>Emotion Control_1</name>
-					<cost type="points">10</cost>
-					<affects>total</affects>
-					<notes>Skin-to-skin contact</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Emotion Control_2</name>
-					<cost type="points">15</cost>
-					<affects>total</affects>
-					<notes>Any touch will suffice</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Emotion Control_3</name>
-					<cost type="points">25</cost>
-					<affects>total</affects>
-					<notes>Emotion control at range; -1 penalty/yard distance</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Emotion Control_4</name>
-					<cost type="points">30</cost>
-					<affects>total</affects>
-					<reference>B550</reference>
-					<notes>Use range penalties p. B550</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Emotion Control_5</name>
-					<cost type="points">55</cost>
-					<affects>total</affects>
-					<reference>B241</reference>
-					<notes>Use long-distance modifiers p. B241</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Emotion Control_6</name>
-					<cost type="points">80</cost>
-					<affects>total</affects>
-					<notes>No penalty for range</notes>
-				</modifier>
-				<reference>PSI61</reference>
-				<notes>Control ability.  You can sway the emotions of others.</notes>
-				<categories>
-					<category>Control</category>
-					<category>Psionics</category>
-					<category>Telepathy</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Emotion Control (Have Suggestion)</name>
+				<name>Major Disease Resistance</name>
 				<type>Mental</type>
 				<base_points>5</base_points>
-				<modifier version="1" enabled="no">
-					<name>Emotion Control_1</name>
-					<cost type="points">0</cost>
+				<modifier version="1">
+					<name>Psychic Healing</name>
+					<cost type="percentage">-10</cost>
 					<affects>total</affects>
-					<notes>Skin-to-skin contact</notes>
 				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Emotion Control_2</name>
-					<cost type="points">0</cost>
-					<affects>total</affects>
-					<notes>Any touch will suffice</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Emotion Control_3</name>
-					<cost type="points">0</cost>
-					<affects>total</affects>
-					<notes>Emotion control at range; -1 penalty/yard distance</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Emotion Control_4</name>
-					<cost type="points">0</cost>
-					<affects>total</affects>
-					<reference>B550</reference>
-					<notes>Use range penalties p. B550</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Emotion Control_5</name>
-					<cost type="points">0</cost>
-					<affects>total</affects>
-					<reference>B241</reference>
-					<notes>Use long-distance modifiers p. B241</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Emotion Control_6</name>
-					<cost type="points">0</cost>
-					<affects>total</affects>
-					<notes>No penalty for range</notes>
-				</modifier>
-				<reference>PSI61</reference>
-				<notes>Control ability.  You can sway the emotions of others.</notes>
+				<reference>PSI49</reference>
+				<notes>+8 to resist disease</notes>
 				<categories>
-					<category>Control</category>
 					<category>Psionics</category>
-					<category>Telepathy</category>
-				</categories>
-				<prereq_list all="yes">
-					<advantage_prereq has="yes">
-						<name compare="is">Suggestion</name>
-						<notes compare="contains">_</notes>
-					</advantage_prereq>
-				</prereq_list>
-			</advantage>
-			<advantage version="3">
-				<name>Mind Swap</name>
-				<type>Mental</type>
-				<modifier version="1" enabled="no">
-					<name>Mind Swap_1</name>
-					<cost type="points">20</cost>
-					<affects>total</affects>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Mind Swap_2</name>
-					<cost type="points">45</cost>
-					<affects>total</affects>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Mind Swap_3</name>
-					<cost type="points">60</cost>
-					<affects>total</affects>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Mind Swap_4</name>
-					<cost type="points">65</cost>
-					<affects>total</affects>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Mind Swap_5</name>
-					<cost type="points">70</cost>
-					<affects>total</affects>
-				</modifier>
-				<reference>PSI62</reference>
-				<notes>Control ability.  You can trade bodies with someone.</notes>
-				<categories>
-					<category>Control</category>
-					<category>Psionics</category>
-					<category>Telepathy</category>
+					<category>Psychic Healing</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Mindwipe</name>
+				<name>Major Ingested Poison Resistance</name>
 				<type>Mental</type>
-				<modifier version="1" enabled="no">
-					<name>Mindwipe_1</name>
-					<cost type="points">20</cost>
+				<base_points>3</base_points>
+				<modifier version="1">
+					<name>Psychic Healing</name>
+					<cost type="percentage">-10</cost>
 					<affects>total</affects>
-					<notes>Skin-to-skin contact</notes>
 				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Mindwipe_2</name>
-					<cost type="points">23</cost>
-					<affects>total</affects>
-					<notes>Any touch will suffice</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Mindwipe_3</name>
-					<cost type="points">26</cost>
-					<affects>total</affects>
-					<notes>Mindwipe at range; -1 penalty/yard distance</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Mindwipe_4</name>
-					<cost type="points">31</cost>
-					<affects>total</affects>
-					<reference>B550</reference>
-					<notes>Use range penalties p. B550</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Mindwipe_5</name>
-					<cost type="points">36</cost>
-					<affects>total</affects>
-					<reference>B241</reference>
-					<notes>Use long-distance modifiers p. B241</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Mindwipe_6</name>
-					<cost type="points">41</cost>
-					<affects>total</affects>
-					<notes>No penalty for range</notes>
-				</modifier>
-				<reference>PSI62</reference>
-				<notes>Control ability.  You can wipe the last few minutes from someone's mind.</notes>
+				<reference>PSI49</reference>
+				<notes>+8 to resist ingested poisons</notes>
 				<categories>
-					<category>Control</category>
 					<category>Psionics</category>
-					<category>Telepathy</category>
+					<category>Psychic Healing</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Sensory Control</name>
+				<name>Major Poison Resistance</name>
 				<type>Mental</type>
-				<modifier version="1" enabled="no">
-					<name>Sensory Control_1</name>
-					<cost type="points">33</cost>
+				<base_points>7</base_points>
+				<modifier version="1">
+					<name>Psychic Healing</name>
+					<cost type="percentage">-10</cost>
 					<affects>total</affects>
-					<notes>Skin-to-skin contact</notes>
 				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Sensory Control_2</name>
-					<cost type="points">40</cost>
-					<affects>total</affects>
-					<notes>Sensory control at range; -1 penalty/yard distance</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Sensory Control_3</name>
-					<cost type="points">43</cost>
-					<affects>total</affects>
-					<reference>B550</reference>
-					<notes>Use range penalties p. B550</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Sensory Control_4</name>
-					<cost type="points">45</cost>
-					<affects>total</affects>
-					<reference>B241</reference>
-					<notes>Use long-distance modifiers p. B241</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Sensory Control_5</name>
-					<cost type="points">48</cost>
-					<affects>total</affects>
-					<notes>No penalty for range</notes>
-				</modifier>
-				<reference>PSI62</reference>
-				<notes>Control ability.  You can control what your target sees, hears, etc.</notes>
+				<reference>PSI49</reference>
+				<notes>+8 to resist poison</notes>
 				<categories>
-					<category>Control</category>
 					<category>Psionics</category>
-					<category>Telepathy</category>
+					<category>Psychic Healing</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Sensory Control (Overload)</name>
+				<name>Major Sickness Resistance</name>
 				<type>Mental</type>
-				<modifier version="1" enabled="no">
-					<name>Sensory Control_1</name>
-					<cost type="points">20</cost>
+				<base_points>7</base_points>
+				<modifier version="1">
+					<name>Psychic Healing</name>
+					<cost type="percentage">-10</cost>
 					<affects>total</affects>
-					<notes>Skin-to-skin contact</notes>
 				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Sensory Control_2</name>
-					<cost type="points">28</cost>
-					<affects>total</affects>
-					<notes>Sensory control at range; -1 penalty/yard distance</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Sensory Control_3</name>
-					<cost type="points">30</cost>
-					<affects>total</affects>
-					<reference>B550</reference>
-					<notes>Use range penalties p. B550</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Sensory Control_4</name>
-					<cost type="points">33</cost>
-					<affects>total</affects>
-					<reference>B241</reference>
-					<notes>Use long-distance modifiers p. B241</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Sensory Control_5</name>
-					<cost type="points">35</cost>
-					<affects>total</affects>
-					<notes>No penalty for range</notes>
-				</modifier>
-				<reference>PSI62</reference>
-				<notes>Control ability.  Your target hallucinates.</notes>
+				<reference>PSI49</reference>
+				<notes>+8 to resist sicknesses</notes>
 				<categories>
-					<category>Control</category>
 					<category>Psionics</category>
-					<category>Telepathy</category>
+					<category>Psychic Healing</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Suggestion</name>
+				<name>Metabolism Control</name>
 				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>5</points_per_level>
+				<modifier version="1">
+					<name>Psychic Healing</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI49</reference>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Healing</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Minor Disease Resistance</name>
+				<type>Mental</type>
+				<base_points>3</base_points>
+				<modifier version="1">
+					<name>Psychic Healing</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI49</reference>
+				<notes>+3 to resist disease</notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Healing</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Minor Ingested Poison Resistance</name>
+				<type>Mental</type>
+				<base_points>3</base_points>
+				<modifier version="1">
+					<name>Psychic Healing</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI49</reference>
+				<notes>+3 to resist ingested poisons</notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Healing</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Minor Poison Resistance</name>
+				<type>Mental</type>
+				<base_points>5</base_points>
+				<modifier version="1">
+					<name>Psychic Healing</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI49</reference>
+				<notes>+3 to resist poison</notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Healing</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Minor Sickness Resistance</name>
+				<type>Mental</type>
+				<base_points>5</base_points>
+				<modifier version="1">
+					<name>Psychic Healing</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI49</reference>
+				<notes>+3 to resist sicknesses</notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Healing</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Natural Doctor</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI48</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychic Healing</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Pharmaceutical Probe</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI48</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychic Healing</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Postmortem</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI48</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychic Healing</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Protected Power (Psychic Healing)</name>
+				<type>Mental</type>
+				<base_points>15</base_points>
+				<modifier version="1">
+					<name>Psychic Healing</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI49</reference>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Healing</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Psychic Healing Talent</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>5</points_per_level>
+				<reference>PSI19</reference>
+				<categories>
+					<category>Power</category>
+					<category>Psychic Healing</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">Aura Reading</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Cure</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Disease Shield</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Life Extension</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Sleep (Psychic Healing)</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Empathy</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Metabolism Control</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Continuing Attack</name>
+					<specialization compare="contains">Psychic Healing</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Crippling Blow</name>
+					<specialization compare="contains">Psychic Healing</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Drugged Weapon</name>
+					<specialization compare="contains">Psychic Healing</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Energizing Defense</name>
+					<specialization compare="contains">Psychic Healing</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Healthful Armor</name>
+					<specialization compare="contains">Psychic Healing</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Resilient Armor</name>
+					<specialization compare="contains">Psychic Healing</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Restorative Armor</name>
+					<specialization compare="contains">Psychic Healing</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Sovereign Armor</name>
+					<specialization compare="contains">Psychic Healing</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Sudden Death</name>
+					<specialization compare="contains">Psychic Healing</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Toxic Strike</name>
+					<specialization compare="contains">Psychic Healing</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Withering Strike</name>
+					<specialization compare="contains">Psychic Healing</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+			</advantage>
+			<advantage version="3">
+				<name>Psychic Surgery</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI48</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychic Healing</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Regeneration</name>
+				<type>Mental</type>
+				<modifier version="1">
+					<name>Psychic Healing</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
 				<modifier version="1" enabled="no">
-					<name>Suggestion_1</name>
+					<name>Slow</name>
 					<cost type="points">10</cost>
 					<affects>total</affects>
-					<notes>Skin-to-skin contact</notes>
 				</modifier>
 				<modifier version="1" enabled="no">
-					<name>Suggestion_2</name>
-					<cost type="points">20</cost>
+					<name>Regular</name>
+					<cost type="points">25</cost>
 					<affects>total</affects>
-					<notes>Any touch will suffice</notes>
 				</modifier>
 				<modifier version="1" enabled="no">
-					<name>Suggestion_3</name>
-					<cost type="points">30</cost>
-					<affects>total</affects>
-					<notes>Suggestion at range; -1 penalty/yard distance</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Suggestion_4</name>
-					<cost type="points">35</cost>
-					<affects>total</affects>
-					<reference>B550</reference>
-					<notes>Use range penalties p. B550</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Suggestion_5</name>
+					<name>Fast</name>
 					<cost type="points">50</cost>
 					<affects>total</affects>
-					<reference>B241</reference>
-					<notes>Use long-distance modifiers p. B241</notes>
 				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Suggestion_6</name>
-					<cost type="points">75</cost>
-					<affects>total</affects>
-					<reference>B241</reference>
-					<notes>Use long-distance modifiers p. B241</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Suggestion_7</name>
-					<cost type="points">100</cost>
-					<affects>total</affects>
-					<notes>No penalty for range</notes>
-				</modifier>
-				<reference>PSI63</reference>
-				<notes>Control ability.  You can send telepathic commands to a subject.</notes>
+				<reference>PSI49</reference>
 				<categories>
-					<category>Control</category>
 					<category>Psionics</category>
-					<category>Telepathy</category>
+					<category>Psychic Healing</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Telecontrol</name>
+				<name>Regrowth</name>
 				<type>Mental</type>
-				<levels>1</levels>
-				<base_points>15</base_points>
-				<points_per_level>15</points_per_level>
-				<reference>PSI64</reference>
-				<notes>Control ability.  You can completely take over the body of a human being. </notes>
+				<base_points>40</base_points>
+				<modifier version="1">
+					<name>Psychic Healing</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI49</reference>
 				<categories>
-					<category>Control</category>
 					<category>Psionics</category>
-					<category>Telepathy</category>
-				</categories>
-			</advantage>
-		</advantage_container>
-		<advantage version="3">
-			<name>Deep Study</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI63</reference>
-			<categories>
-				<category>Communication</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Telepathy</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>I Know What You Mean</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI63</reference>
-			<categories>
-				<category>Communication</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Telepathy</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Intimidation Factor</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI63</reference>
-			<categories>
-				<category>Offense</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Telepathy</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Mindlink</name>
-			<type>Mental</type>
-			<modifier version="1" enabled="no">
-				<name>Single person</name>
-				<cost type="points">5</cost>
-				<affects>total</affects>
-				<reference>B70</reference>
-				<notes>@Who@</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>2-9 people</name>
-				<cost type="points">10</cost>
-				<affects>total</affects>
-				<reference>B70</reference>
-				<notes>@Who@</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>10-99 people</name>
-				<cost type="points">20</cost>
-				<affects>total</affects>
-				<reference>B70</reference>
-				<notes>@Who@</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>100-999 people</name>
-				<cost type="points">30</cost>
-				<affects>total</affects>
-				<reference>B70</reference>
-				<notes>@Who@</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>1000-9999 people</name>
-				<cost type="points">40</cost>
-				<affects>total</affects>
-				<reference>B70</reference>
-				<notes>@Who@</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>10000-99999 people</name>
-				<cost type="points">50</cost>
-				<affects>total</affects>
-				<reference>B70</reference>
-				<notes>@Who@</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Broadcast</name>
-				<cost type="percentage">50</cost>
-				<affects>total</affects>
-				<reference>B91</reference>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Cybernetic</name>
-				<cost type="percentage">50</cost>
-				<affects>total</affects>
-				<reference>B69</reference>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Sensory</name>
-				<cost type="percentage">20</cost>
-				<affects>total</affects>
-				<reference>B69</reference>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Universal</name>
-				<cost type="percentage">50</cost>
-				<affects>total</affects>
-				<reference>B69</reference>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Video</name>
-				<cost type="percentage">40</cost>
-				<affects>total</affects>
-				<reference>B91</reference>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Cybernetic Only</name>
-				<cost type="percentage">-50</cost>
-				<affects>total</affects>
-				<reference>B70</reference>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Racial</name>
-				<cost type="percentage">-20</cost>
-				<affects>total</affects>
-				<reference>B70</reference>
-				<notes>@Race@</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Sensory Only</name>
-				<cost type="percentage">-20</cost>
-				<affects>total</affects>
-				<reference>B70</reference>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Telecommunication</name>
-				<cost type="percentage">-20</cost>
-				<affects>total</affects>
-				<reference>B70</reference>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Vague</name>
-				<cost type="percentage">-50</cost>
-				<affects>total</affects>
-				<reference>B91</reference>
-			</modifier>
-			<modifier version="1">
-				<name>Telepathy</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI67</reference>
-			<categories>
-				<category>Communication</category>
-				<category>Psionics</category>
-				<category>Telepathy</category>
-			</categories>
-		</advantage>
-		<advantage_container version="3" open="yes">
-			<name>Offense</name>
-			<reference>PSI64</reference>
-			<notes>Branch of Telepathy</notes>
-			<categories>
-				<category>Offense</category>
-				<category>Psionics</category>
-				<category>Telepathy</category>
-			</categories>
-			<advantage version="3">
-				<name>Instill Fear</name>
-				<type>Mental</type>
-				<levels>1</levels>
-				<base_points>15</base_points>
-				<points_per_level>3</points_per_level>
-				<reference>PSI64</reference>
-				<notes>Offense ability. Project fear and terror into someone's heart.</notes>
-				<categories>
-					<category>Offense</category>
-					<category>Psionics</category>
-					<category>Telepathy</category>
+					<category>Psychic Healing</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Mental Blow</name>
-				<type>Mental</type>
-				<modifier version="1" enabled="no">
-					<name>Mental Blow_1</name>
-					<cost type="points">17</cost>
-					<affects>total</affects>
-					<notes>Skin-to-skin contact</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Mental Blow_2</name>
-					<cost type="points">20</cost>
-					<affects>total</affects>
-					<notes>Any touch will suffice</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Mental Blow_3</name>
-					<cost type="points">23</cost>
-					<affects>total</affects>
-					<notes>Mental Blow at range; -1 penalty/yard distance</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Mental Blow_4</name>
-					<cost type="points">28</cost>
-					<affects>total</affects>
-					<reference>B550</reference>
-					<notes>Use range penalties p. B550</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Mental Blow_5</name>
-					<cost type="points">33</cost>
-					<affects>total</affects>
-					<reference>B241</reference>
-					<notes>Use long-distance modifiers p. B241</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Mental Blow_6</name>
-					<cost type="points">38</cost>
-					<affects>total</affects>
-					<notes>No penalty for range</notes>
-				</modifier>
-				<reference>PSI65</reference>
-				<notes>Offense ability. Overload someone's brain with a psychic attack. </notes>
-				<categories>
-					<category>Communication</category>
-					<category>Psionics</category>
-					<category>Telepathy</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Mental Stab</name>
-				<type>Mental</type>
-				<modifier version="1" enabled="no">
-					<name>Mental Stab_1</name>
-					<cost type="points">33</cost>
-					<affects>total</affects>
-					<notes>Skin-to-skin contact</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Mental Stab_2</name>
-					<cost type="points">43</cost>
-					<affects>total</affects>
-					<notes>Any touch will suffice</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Mental Stab_3</name>
-					<cost type="points">52</cost>
-					<affects>total</affects>
-					<notes>Mental Blow at range; -1 penalty/yard distance</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Mental Stab_4</name>
-					<cost type="points">69</cost>
-					<affects>total</affects>
-					<reference>B550</reference>
-					<notes>Use range penalties p. B550</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Mental Stab_5</name>
-					<cost type="points">85</cost>
-					<affects>total</affects>
-					<reference>B241</reference>
-					<notes>Use long-distance modifiers p. B241</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Mental Stab_6</name>
-					<cost type="points">101</cost>
-					<affects>total</affects>
-					<notes>No penalty for range</notes>
-				</modifier>
-				<reference>PSI65</reference>
-				<notes>Offense ability. Psychically attack someone's brain, doing real damage.</notes>
-				<categories>
-					<category>Communication</category>
-					<category>Psionics</category>
-					<category>Telepathy</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Sleep (Telepathy)</name>
+				<name>Sleep (Psychic Healing)</name>
 				<type>Mental</type>
 				<modifier version="1" enabled="no">
 					<name>Sleep_1</name>
@@ -6212,866 +4248,2960 @@
 				</modifier>
 				<modifier version="1" enabled="no">
 					<name>Sleep_4</name>
+					<reference>B550</reference>
 					<cost type="points">36</cost>
 					<affects>total</affects>
-					<reference>B550</reference>
 					<notes>Use range penalties p. B550</notes>
 				</modifier>
-				<reference>PSI66</reference>
-				<notes>Offense ability. You safely put someone to sleep.</notes>
+				<reference>PSI49</reference>
+				<notes>Psychic healing ability. You safely put someone to sleep.</notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Healing</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Soothing Touch</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI48</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychic Healing</category>
+				</categories>
+			</advantage>
+		</advantage_container>
+		<advantage_container version="3" open="no">
+			<name>Psychic Vampirism</name>
+			<reference>PSI49</reference>
+			<categories>
+				<category>Psionics</category>
+				<category>Psychic Vampirism</category>
+			</categories>
+			<advantage version="3">
+				<name>Blood Healing</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI51</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychic Vampirism</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Controllable Lifebane</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI51</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychic Vampirism</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Detect Life</name>
+				<type>Mental</type>
+				<base_points>30</base_points>
+				<modifier version="1">
+					<name>Psychic Vampirism</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI52</reference>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Vampirism</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Drain DX</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<base_points>22</base_points>
+				<points_per_level>2</points_per_level>
+				<reference>PSI50</reference>
+				<notes>Psychic vampirism ability. Reduce someone's DX.</notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Vampirism</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Drain Emotion</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<base_points>5</base_points>
+				<points_per_level>5</points_per_level>
+				<reference>PSI50</reference>
+				<notes>Psychic vampirism ability. Reduce someone's HT.</notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Vampirism</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Drain HT</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<base_points>22</base_points>
+				<points_per_level>2</points_per_level>
+				<reference>PSI50</reference>
+				<notes>Psychic vampirism ability. Reduce someone's HT.</notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Vampirism</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Drain IQ</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<base_points>22</base_points>
+				<points_per_level>2</points_per_level>
+				<reference>PSI50</reference>
+				<notes>Psychic vampirism ability. Reduce someone's IQ.</notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Vampirism</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Drain ST</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<base_points>22</base_points>
+				<points_per_level>2</points_per_level>
+				<reference>PSI50</reference>
+				<notes>Psychic vampirism ability. Reduce someone's ST.</notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Vampirism</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Invigoration</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI51</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychic Vampirism</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Pleasant Theft</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI51</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychic Vampirism</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Poison Charm</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI51</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychic Vampirism</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Protected Power (Psychic Vampirism)</name>
+				<type>Mental</type>
+				<base_points>5</base_points>
+				<modifier version="1">
+					<name>Psychic Vampirism</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI52</reference>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Vampirism</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Psychic Vampirism Talent</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>5</points_per_level>
+				<reference>PSI19</reference>
+				<categories>
+					<category>Power</category>
+					<category>Psychic Vampirism</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">Detect Life</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Drain DX</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Drain Emotion</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Drain HT</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Drain IQ</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Drain ST</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Steal Dreams</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Steal Energy</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Steal Life</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Steal Power</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Annihilating Weapon</name>
+					<specialization compare="contains">Psychic Vampirism</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Chilling Strike</name>
+					<specialization compare="contains">Psychic Vampirism</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Corrosive Strike</name>
+					<specialization compare="contains">Psychic Vampirism</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Energizing Defense</name>
+					<specialization compare="contains">Psychic Vampirism</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Envenomed Weapon</name>
+					<specialization compare="contains">Psychic Vampirism</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Sudden Death</name>
+					<specialization compare="contains">Psychic Vampirism</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Toxic Strike</name>
+					<specialization compare="contains">Psychic Vampirism</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Traumatic Blow</name>
+					<specialization compare="contains">Psychic Vampirism</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Vampiric Weapon</name>
+					<specialization compare="contains">Psychic Vampirism</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Vengeful Defense</name>
+					<specialization compare="contains">Psychic Vampirism</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Withering Strike</name>
+					<specialization compare="contains">Psychic Vampirism</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+			</advantage>
+			<advantage version="3">
+				<name>Schadenfreude</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI51</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychic Vampirism</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Social Vampire</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI51</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychic Vampirism</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Steal Dreams</name>
+				<type>Mental</type>
+				<modifier version="1" enabled="no">
+					<name>Steal Dreams_1</name>
+					<cost type="points">23</cost>
+					<affects>total</affects>
+					<notes>Skin-to-skin contact</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Steal Dreams_2</name>
+					<cost type="points">31</cost>
+					<affects>total</affects>
+					<notes>Any touch will suffice</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Steal Dreams_3</name>
+					<cost type="points">40</cost>
+					<affects>total</affects>
+					<notes>Steal dreams at range; -1 penalty/yard distance. </notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Steal Dreams_4</name>
+					<reference>B550</reference>
+					<cost type="points">0</cost>
+					<affects>total</affects>
+					<notes>Use range penalties p. B550</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Steal Dreams_5</name>
+					<reference>B241</reference>
+					<cost type="points">67</cost>
+					<affects>total</affects>
+					<notes>Use long-distance modifiers p. B241</notes>
+				</modifier>
+				<reference>PSI50</reference>
+				<notes>Psychic vampirism ability. Rob someone of their dreams. </notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Vampirism</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Steal Energy</name>
+				<type>Mental</type>
+				<modifier version="1" enabled="no">
+					<name>Steal Energy_1</name>
+					<cost type="points">32</cost>
+					<affects>total</affects>
+					<notes>30 seconds</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Steal Energy_2</name>
+					<cost type="points">34</cost>
+					<affects>total</affects>
+					<notes>15 seconds</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Steal Energy_3</name>
+					<cost type="points">37</cost>
+					<affects>total</affects>
+					<notes>8 seconds</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Steal Energy_4</name>
+					<cost type="points">39</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Steal Energy_5</name>
+					<cost type="points">42</cost>
+					<affects>total</affects>
+					<notes>4 seconds</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Steal Energy_6</name>
+					<cost type="points">44</cost>
+					<affects>total</affects>
+					<notes>1 second</notes>
+				</modifier>
+				<reference>PSI51</reference>
+				<notes>Psychic vampirism ability. Rob someone of their FP to replenish your own. </notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Vampirism</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Steal Life</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<base_points>21</base_points>
+				<points_per_level>4</points_per_level>
+				<reference>PSI52</reference>
+				<notes>Psychic vampirism ability. Rob someone of their HP to replenish your own.</notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Vampirism</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Steal Power</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<base_points>45</base_points>
+				<points_per_level>10</points_per_level>
+				<reference>PSI52</reference>
+				<notes>Psychic vampirism ability. Steal someone's psi abilities. </notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychic Vampirism</category>
+				</categories>
+			</advantage>
+		</advantage_container>
+		<advantage_container version="3" open="no">
+			<name>Psychokinesis</name>
+			<reference>PSI53</reference>
+			<categories>
+				<category>Psionics</category>
+				<category>Psychokinesis</category>
+			</categories>
+			<advantage version="3">
+				<name>Aerokinesis</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI56</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychokinesis</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Chill Factor</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI56</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychokinesis</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Cryokinesis</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>13</points_per_level>
+				<reference>PSI55</reference>
+				<notes>Telekinesis ability. You can lower temperatures.</notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychokinesis</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Extra ST without HP</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>8</points_per_level>
+				<modifier version="1">
+					<name>Psychokinesis</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI57</reference>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychokinesis</category>
+					<category>Telekinesis</category>
+				</categories>
+				<attribute_bonus>
+					<attribute>st</attribute>
+					<amount per_level="yes">1</amount>
+				</attribute_bonus>
+				<attribute_bonus>
+					<attribute>hp</attribute>
+					<amount per_level="yes">-1</amount>
+				</attribute_bonus>
+			</advantage>
+			<advantage version="3">
+				<name>Gecko Grip</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI56</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychokinesis</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Hydrokinesis</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI56</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychokinesis</category>
+					<category>Telekinesis</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Ignition</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI56</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychokinesis</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>PK Shield</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>4</points_per_level>
+				<reference>PSI56</reference>
+				<notes>Telekinesis ability. You can resist or deflect incoming physical attacks. </notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychokinesis</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Protected Power (Psychokinesis)</name>
+				<type>Mental</type>
+				<base_points>5</base_points>
+				<modifier version="1">
+					<name>Psychokinesis</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI57</reference>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychokinesis</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Psychokinesis Talent</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>5</points_per_level>
+				<reference>PSI19</reference>
+				<categories>
+					<category>Power</category>
+					<category>Psychokinesis</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">TK Grab</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">TK Crush</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">TK Bullet</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Levitation</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Telekinetic Control</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Pyrokinesis</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">PK Shield</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Cryokinesis</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Blunting Armor</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Burning Strike</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Chilling Strike</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Crushing Strike</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Cutting Strike</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Dancing Shield</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Dancing Weapon</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Expand Armor</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Far Shot</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Forceful Blow</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Guided Weapon</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Impaling Strike</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Impenetrable Armor</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Incendiary Weapon</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Lighten Armor</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Padded Armor</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Piercing Strike</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Project Blow</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Reinforce Armor</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Rigid Armor</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Telescoping Weapon</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Traumatic Blow</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Widen Shield</name>
+					<specialization compare="contains">Psychokinesis</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<prereq_list all="yes">
+					<advantage_prereq has="no">
+						<name compare="is">Telekinesis Talent</name>
+						<notes compare="is anything"></notes>
+						<level compare="at least">1</level>
+					</advantage_prereq>
+				</prereq_list>
+			</advantage>
+			<advantage version="3">
+				<name>Pyrokinesis</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>14</points_per_level>
+				<reference>PSI56</reference>
+				<notes>Telekinesis ability. You can increase temperatures.</notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychokinesis</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Small-Scale TK</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI56</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychokinesis</category>
+					<category>Telekinesis</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Strong Blade</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI56</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychokinesis</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Super Jump</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>10</points_per_level>
+				<modifier version="1">
+					<name>Psychokinesis</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI57</reference>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychokinesis</category>
+					<category>Telekinesis</category>
+				</categories>
+				<attribute_bonus>
+					<attribute>st</attribute>
+					<amount per_level="yes">1</amount>
+				</attribute_bonus>
+			</advantage>
+			<advantage_container version="3" open="yes">
+				<name>Telekinesis</name>
+				<reference>PSI53</reference>
+				<notes>Branch of psychokinesis</notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychokinesis</category>
+					<category>Telekinesis</category>
+				</categories>
+				<advantage version="3">
+					<name>Levitation</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<base_points>12</base_points>
+					<points_per_level>2</points_per_level>
+					<reference>PSI55</reference>
+					<notes>Telekinesis ability. You can pick yourself up and fly.</notes>
+					<categories>
+						<category>Psionics</category>
+						<category>Psychokinesis</category>
+						<category>Telekinesis</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Telekinetic Control</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<points_per_level>8</points_per_level>
+					<reference>PSI54</reference>
+					<notes>Telekinesis ability. Unified telekinetic abilities.</notes>
+					<categories>
+						<category>Psionics</category>
+						<category>Psychokinesis</category>
+						<category>Telekinesis</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>TK Bullet</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<points_per_level>5</points_per_level>
+					<ranged_weapon>
+						<damage type="pi" base="1d-1"/>
+						<usage>Bullet</usage>
+						<accuracy>3</accuracy>
+						<range>500/2000</range>
+						<rate_of_fire>1</rate_of_fire>
+						<recoil>1</recoil>
+						<default>
+							<type>DX</type>
+							<modifier>-4</modifier>
+						</default>
+						<default>
+							<type>Skill</type>
+							<name>Innate Attack</name>
+							<modifier>-2</modifier>
+						</default>
+						<default>
+							<type>Skill</type>
+							<name>Innate Attack</name>
+							<specialization>Projectile</specialization>
+							<modifier>0</modifier>
+						</default>
+					</ranged_weapon>
+					<ranged_weapon>
+						<damage type="pi+" base="1d-1"/>
+						<usage>Flat Edge</usage>
+						<accuracy>3</accuracy>
+						<range>500/2000</range>
+						<rate_of_fire>1</rate_of_fire>
+						<recoil>1</recoil>
+						<default>
+							<type>DX</type>
+							<modifier>-4</modifier>
+						</default>
+						<default>
+							<type>Skill</type>
+							<name>Innate Attack</name>
+							<modifier>-2</modifier>
+						</default>
+						<default>
+							<type>Skill</type>
+							<name>Innate Attack</name>
+							<specialization>Projectile</specialization>
+							<modifier>0</modifier>
+						</default>
+					</ranged_weapon>
+					<ranged_weapon>
+						<damage type="pi" base="1d-1" armor_divisor="2.0"/>
+						<usage>Sharp Edge</usage>
+						<accuracy>3</accuracy>
+						<range>500/2000</range>
+						<rate_of_fire>1</rate_of_fire>
+						<recoil>1</recoil>
+						<default>
+							<type>DX</type>
+							<modifier>-4</modifier>
+						</default>
+						<default>
+							<type>Skill</type>
+							<name>Innate Attack</name>
+							<modifier>-2</modifier>
+						</default>
+						<default>
+							<type>Skill</type>
+							<name>Innate Attack</name>
+							<specialization>Projectile</specialization>
+							<modifier>0</modifier>
+						</default>
+					</ranged_weapon>
+					<ranged_weapon>
+						<damage type="pi" base="1d-1"/>
+						<usage>Rapid Fire</usage>
+						<accuracy>3</accuracy>
+						<range>500/2000</range>
+						<rate_of_fire>7</rate_of_fire>
+						<recoil>1</recoil>
+						<default>
+							<type>DX</type>
+							<modifier>-4</modifier>
+						</default>
+						<default>
+							<type>Skill</type>
+							<name>Innate Attack</name>
+							<modifier>-2</modifier>
+						</default>
+						<default>
+							<type>Skill</type>
+							<name>Innate Attack</name>
+							<specialization>Projectile</specialization>
+							<modifier>0</modifier>
+						</default>
+					</ranged_weapon>
+					<ranged_weapon>
+						<damage type="pi" base="1d-2"/>
+						<usage>Silencer</usage>
+						<accuracy>3</accuracy>
+						<range>500/2000</range>
+						<rate_of_fire>1</rate_of_fire>
+						<recoil>1</recoil>
+						<default>
+							<type>DX</type>
+							<modifier>-4</modifier>
+						</default>
+						<default>
+							<type>Skill</type>
+							<name>Innate Attack</name>
+							<modifier>-2</modifier>
+						</default>
+						<default>
+							<type>Skill</type>
+							<name>Innate Attack</name>
+							<specialization>Projectile</specialization>
+							<modifier>0</modifier>
+						</default>
+					</ranged_weapon>
+					<reference>PSI53</reference>
+					<notes>Telekinesis ability. Throw stones at bullet-like speeds. </notes>
+					<categories>
+						<category>Psionics</category>
+						<category>Psychokinesis</category>
+						<category>Telekinesis</category>
+					</categories>
+					<weapon_bonus>
+						<name compare="is">Innate Attack</name>
+						<specialization compare="is">Projectile</specialization>
+						<level compare="at least">1</level>
+						<category compare="is anything"></category>
+						<amount>1</amount>
+					</weapon_bonus>
+				</advantage>
+				<advantage version="3">
+					<name>TK Crush</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<points_per_level>5</points_per_level>
+					<ranged_weapon>
+						<damage type="pi/level" base="+1"/>
+						<usage>Gaze</usage>
+						<range>Within Sight</range>
+						<rate_of_fire>1</rate_of_fire>
+						<recoil>1</recoil>
+						<default>
+							<type>DX</type>
+							<modifier>-4</modifier>
+						</default>
+						<default>
+							<type>Skill</type>
+							<name>Innate Attack</name>
+							<modifier>-2</modifier>
+						</default>
+						<default>
+							<type>Skill</type>
+							<name>Innate Attack</name>
+							<specialization>Gaze</specialization>
+							<modifier>0</modifier>
+						</default>
+					</ranged_weapon>
+					<reference>PSI54</reference>
+					<notes>Telekinesis ability. Crush someone's internal organs by staring at them. </notes>
+					<categories>
+						<category>Psionics</category>
+						<category>Psychokinesis</category>
+						<category>Telekinesis</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>TK Grab</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<points_per_level>7</points_per_level>
+					<modifier version="1" enabled="no">
+						<name>Short Ranged (20 yards)</name>
+						<cost type="percentage">-43</cost>
+						<affects>total</affects>
+					</modifier>
+					<reference>PSI54</reference>
+					<notes>Telekinesis ability. Pick up and move objects from a distance. </notes>
+					<categories>
+						<category>Psionics</category>
+						<category>Psychokinesis</category>
+						<category>Telekinesis</category>
+					</categories>
+				</advantage>
+			</advantage_container>
+			<advantage version="3">
+				<name>Temperature Tolerance</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>1</points_per_level>
+				<modifier version="1">
+					<name>Psychokinesis</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI57</reference>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychokinesis</category>
+				</categories>
+				<attribute_bonus>
+					<attribute>st</attribute>
+					<amount per_level="yes">1</amount>
+				</attribute_bonus>
+			</advantage>
+			<advantage version="3">
+				<name>TK Tether</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI56</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychokinesis</category>
+					<category>Telekinesis</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Umbrella</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI56</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Psychokinesis</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Walk on Air</name>
+				<type>Mental</type>
+				<base_points>20</base_points>
+				<modifier version="1">
+					<name>Psychokinesis</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI57</reference>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychokinesis</category>
+					<category>Telekinesis</category>
+				</categories>
+				<attribute_bonus>
+					<attribute>st</attribute>
+					<amount per_level="yes">1</amount>
+				</attribute_bonus>
+			</advantage>
+			<advantage version="3">
+				<name>Walk on Liquid</name>
+				<type>Mental</type>
+				<base_points>15</base_points>
+				<modifier version="1">
+					<name>Psychokinesis</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI57</reference>
+				<categories>
+					<category>Psionics</category>
+					<category>Psychokinesis</category>
+					<category>Telekinesis</category>
+				</categories>
+				<attribute_bonus>
+					<attribute>st</attribute>
+					<amount per_level="yes">1</amount>
+				</attribute_bonus>
+			</advantage>
+		</advantage_container>
+		<advantage_container version="3" open="no">
+			<name>Telepathy</name>
+			<reference>PSI57</reference>
+			<categories>
+				<category>Psionics</category>
+				<category>Telepathy</category>
+			</categories>
+			<advantage version="3">
+				<name>Avatar</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI63</reference>
+				<categories>
+					<category>Communication</category>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Telepathy</category>
+				</categories>
+			</advantage>
+			<advantage_container version="3" open="yes">
+				<name>Communication</name>
+				<reference>PSI57</reference>
+				<notes>Branch of Telepathy</notes>
+				<categories>
+					<category>Communication</category>
+					<category>Psionics</category>
+					<category>Telepathy</category>
+				</categories>
+				<advantage version="3">
+					<name>Borrow Skill</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<base_points>4</base_points>
+					<points_per_level>3</points_per_level>
+					<reference>PSI57</reference>
+					<notes>Communication ability. Borrow a skill or language from someone.</notes>
+					<categories>
+						<category>Communication</category>
+						<category>Psionics</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Emotion Sense</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Emotion Sense_1</name>
+						<cost type="points">3</cost>
+						<affects>total</affects>
+						<notes>Skin-to-skin contact</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Emotion Sense_2</name>
+						<reference>B550</reference>
+						<cost type="points">9</cost>
+						<affects>total</affects>
+						<notes>Use range penalties p. B550</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Emotion Sense_3</name>
+						<reference>B241</reference>
+						<cost type="points">18</cost>
+						<affects>total</affects>
+						<notes>Use long-distance modifiers p. B241</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Emotion Sense_4</name>
+						<cost type="points">20</cost>
+						<affects>total</affects>
+						<notes>No range penalties</notes>
+					</modifier>
+					<reference>PSI58</reference>
+					<notes>Communication ability. You get a brief flash of the emotions from the subject. </notes>
+					<categories>
+						<category>Communication</category>
+						<category>Psionics</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Telereceive</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Telereceive_1</name>
+						<cost type="points">21</cost>
+						<affects>total</affects>
+						<notes>Skin-to-skin contact</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telereceive_2</name>
+						<cost type="points">36</cost>
+						<affects>total</affects>
+						<notes>Any touch will suffice</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telereceive_3</name>
+						<cost type="points">42</cost>
+						<affects>total</affects>
+						<notes>Telereceive at range; -1 penalty/yard distance</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telereceive_4</name>
+						<reference>B550</reference>
+						<cost type="points">45</cost>
+						<affects>total</affects>
+						<notes>Use range penalties p. B550</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telereceive_5</name>
+						<reference>B241</reference>
+						<cost type="points">60</cost>
+						<affects>total</affects>
+						<notes>Use long-distance modifiers p. B241</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telereceive_6</name>
+						<cost type="points">75</cost>
+						<affects>total</affects>
+						<notes>No penalty for range</notes>
+					</modifier>
+					<reference>PSI58</reference>
+					<notes>Communication ability. You can read another person's thoughts. </notes>
+					<categories>
+						<category>Communication</category>
+						<category>Psionics</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Telereceive (Shallow)</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Telereceive_1</name>
+						<cost type="points">9</cost>
+						<affects>total</affects>
+						<notes>Skin-to-skin contact</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telereceive_2</name>
+						<cost type="points">18</cost>
+						<affects>total</affects>
+						<notes>Any touch will suffice</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telereceive_3</name>
+						<cost type="points">24</cost>
+						<affects>total</affects>
+						<notes>Telereceive at range; -1 penalty/yard distance</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telereceive_4</name>
+						<reference>B550</reference>
+						<cost type="points">27</cost>
+						<affects>total</affects>
+						<notes>Use range penalties p. B550</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telereceive_5</name>
+						<reference>B241</reference>
+						<cost type="points">42</cost>
+						<affects>total</affects>
+						<notes>Use long-distance modifiers p. B241</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telereceive_6</name>
+						<cost type="points">57</cost>
+						<affects>total</affects>
+						<notes>No penalty for range</notes>
+					</modifier>
+					<reference>PSI58</reference>
+					<notes>Communication ability. You can read another person's surface thoughts. </notes>
+					<categories>
+						<category>Communication</category>
+						<category>Psionics</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Telesend</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Telesend_1</name>
+						<cost type="points">9</cost>
+						<affects>total</affects>
+						<notes>Skin-to-skin contact</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telesend_2</name>
+						<cost type="points">18</cost>
+						<affects>total</affects>
+						<notes>Any touch will suffice</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telesend_3</name>
+						<cost type="points">21</cost>
+						<affects>total</affects>
+						<notes>Telesend at range; -1 penalty/yard distance</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telesend_4</name>
+						<reference>B550</reference>
+						<cost type="points">24</cost>
+						<affects>total</affects>
+						<notes>Use range penalties p. B550</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telesend_5</name>
+						<reference>B241</reference>
+						<cost type="points">27</cost>
+						<affects>total</affects>
+						<notes>Use long-distance modifiers p. B241</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telesend_6</name>
+						<cost type="points">42</cost>
+						<affects>total</affects>
+						<notes>No penalty for range</notes>
+					</modifier>
+					<reference>PSI60</reference>
+					<notes>Communication ability. You can read project your thoughts into another's mind. </notes>
+					<categories>
+						<category>Communication</category>
+						<category>Psionics</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Telespeak</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Telespeak_1</name>
+						<cost type="points">18</cost>
+						<affects>total</affects>
+						<notes>Skin-to-skin contact</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telespeak_2</name>
+						<cost type="points">30</cost>
+						<affects>total</affects>
+						<notes>Any touch will suffice</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telespeak_3</name>
+						<cost type="points">39</cost>
+						<affects>total</affects>
+						<notes>Telespeak at range; -1 penalty/yard distance</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telespeak_4</name>
+						<reference>B550</reference>
+						<cost type="points">45</cost>
+						<affects>total</affects>
+						<notes>Use range penalties p. B550</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telespeak_5</name>
+						<reference>B241</reference>
+						<cost type="points">63</cost>
+						<affects>total</affects>
+						<notes>Use long-distance modifiers p. B241</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telespeak_6</name>
+						<cost type="points">93</cost>
+						<affects>total</affects>
+						<notes>No penalty for range</notes>
+					</modifier>
+					<reference>PSI59</reference>
+					<notes>Communication ability. You can converse with someone telepathically. </notes>
+					<categories>
+						<category>Communication</category>
+						<category>Psionics</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+			</advantage_container>
+			<advantage_container version="3" open="yes">
+				<name>Control</name>
+				<reference>PSI60</reference>
+				<notes>Branch of Telepathy</notes>
+				<categories>
+					<category>Control</category>
+					<category>Psionics</category>
+					<category>Telepathy</category>
+				</categories>
+				<advantage version="3">
+					<name>Aspect</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<points_per_level>4</points_per_level>
+					<reference>PSI61</reference>
+					<notes>Control ability.  You can alter how people feel about you. </notes>
+					<categories>
+						<category>Control</category>
+						<category>Psionics</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Emotion Control</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Emotion Control_1</name>
+						<cost type="points">10</cost>
+						<affects>total</affects>
+						<notes>Skin-to-skin contact</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Emotion Control_2</name>
+						<cost type="points">15</cost>
+						<affects>total</affects>
+						<notes>Any touch will suffice</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Emotion Control_3</name>
+						<cost type="points">25</cost>
+						<affects>total</affects>
+						<notes>Emotion control at range; -1 penalty/yard distance</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Emotion Control_4</name>
+						<reference>B550</reference>
+						<cost type="points">30</cost>
+						<affects>total</affects>
+						<notes>Use range penalties p. B550</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Emotion Control_5</name>
+						<reference>B241</reference>
+						<cost type="points">55</cost>
+						<affects>total</affects>
+						<notes>Use long-distance modifiers p. B241</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Emotion Control_6</name>
+						<cost type="points">80</cost>
+						<affects>total</affects>
+						<notes>No penalty for range</notes>
+					</modifier>
+					<reference>PSI61</reference>
+					<notes>Control ability.  You can sway the emotions of others.</notes>
+					<categories>
+						<category>Control</category>
+						<category>Psionics</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Emotion Control (Have Suggestion)</name>
+					<type>Mental</type>
+					<base_points>5</base_points>
+					<modifier version="1" enabled="no">
+						<name>Emotion Control_1</name>
+						<cost type="points">0</cost>
+						<affects>total</affects>
+						<notes>Skin-to-skin contact</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Emotion Control_2</name>
+						<cost type="points">0</cost>
+						<affects>total</affects>
+						<notes>Any touch will suffice</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Emotion Control_3</name>
+						<cost type="points">0</cost>
+						<affects>total</affects>
+						<notes>Emotion control at range; -1 penalty/yard distance</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Emotion Control_4</name>
+						<reference>B550</reference>
+						<cost type="points">0</cost>
+						<affects>total</affects>
+						<notes>Use range penalties p. B550</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Emotion Control_5</name>
+						<reference>B241</reference>
+						<cost type="points">0</cost>
+						<affects>total</affects>
+						<notes>Use long-distance modifiers p. B241</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Emotion Control_6</name>
+						<cost type="points">0</cost>
+						<affects>total</affects>
+						<notes>No penalty for range</notes>
+					</modifier>
+					<reference>PSI61</reference>
+					<notes>Control ability.  You can sway the emotions of others.</notes>
+					<categories>
+						<category>Control</category>
+						<category>Psionics</category>
+						<category>Telepathy</category>
+					</categories>
+					<prereq_list all="yes">
+						<advantage_prereq has="yes">
+							<name compare="is">Suggestion</name>
+							<notes compare="contains">_</notes>
+						</advantage_prereq>
+					</prereq_list>
+				</advantage>
+				<advantage version="3">
+					<name>Mind Swap</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Mind Swap_1</name>
+						<cost type="points">20</cost>
+						<affects>total</affects>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Mind Swap_2</name>
+						<cost type="points">45</cost>
+						<affects>total</affects>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Mind Swap_3</name>
+						<cost type="points">60</cost>
+						<affects>total</affects>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Mind Swap_4</name>
+						<cost type="points">65</cost>
+						<affects>total</affects>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Mind Swap_5</name>
+						<cost type="points">70</cost>
+						<affects>total</affects>
+					</modifier>
+					<reference>PSI62</reference>
+					<notes>Control ability.  You can trade bodies with someone.</notes>
+					<categories>
+						<category>Control</category>
+						<category>Psionics</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Mindwipe</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Mindwipe_1</name>
+						<cost type="points">20</cost>
+						<affects>total</affects>
+						<notes>Skin-to-skin contact</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Mindwipe_2</name>
+						<cost type="points">23</cost>
+						<affects>total</affects>
+						<notes>Any touch will suffice</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Mindwipe_3</name>
+						<cost type="points">26</cost>
+						<affects>total</affects>
+						<notes>Mindwipe at range; -1 penalty/yard distance</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Mindwipe_4</name>
+						<reference>B550</reference>
+						<cost type="points">31</cost>
+						<affects>total</affects>
+						<notes>Use range penalties p. B550</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Mindwipe_5</name>
+						<reference>B241</reference>
+						<cost type="points">36</cost>
+						<affects>total</affects>
+						<notes>Use long-distance modifiers p. B241</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Mindwipe_6</name>
+						<cost type="points">41</cost>
+						<affects>total</affects>
+						<notes>No penalty for range</notes>
+					</modifier>
+					<reference>PSI62</reference>
+					<notes>Control ability.  You can wipe the last few minutes from someone's mind.</notes>
+					<categories>
+						<category>Control</category>
+						<category>Psionics</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Sensory Control</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Sensory Control_1</name>
+						<cost type="points">33</cost>
+						<affects>total</affects>
+						<notes>Skin-to-skin contact</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Sensory Control_2</name>
+						<cost type="points">40</cost>
+						<affects>total</affects>
+						<notes>Sensory control at range; -1 penalty/yard distance</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Sensory Control_3</name>
+						<reference>B550</reference>
+						<cost type="points">43</cost>
+						<affects>total</affects>
+						<notes>Use range penalties p. B550</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Sensory Control_4</name>
+						<reference>B241</reference>
+						<cost type="points">45</cost>
+						<affects>total</affects>
+						<notes>Use long-distance modifiers p. B241</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Sensory Control_5</name>
+						<cost type="points">48</cost>
+						<affects>total</affects>
+						<notes>No penalty for range</notes>
+					</modifier>
+					<reference>PSI62</reference>
+					<notes>Control ability.  You can control what your target sees, hears, etc.</notes>
+					<categories>
+						<category>Control</category>
+						<category>Psionics</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Sensory Control (Overload)</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Sensory Control_1</name>
+						<cost type="points">20</cost>
+						<affects>total</affects>
+						<notes>Skin-to-skin contact</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Sensory Control_2</name>
+						<cost type="points">28</cost>
+						<affects>total</affects>
+						<notes>Sensory control at range; -1 penalty/yard distance</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Sensory Control_3</name>
+						<reference>B550</reference>
+						<cost type="points">30</cost>
+						<affects>total</affects>
+						<notes>Use range penalties p. B550</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Sensory Control_4</name>
+						<reference>B241</reference>
+						<cost type="points">33</cost>
+						<affects>total</affects>
+						<notes>Use long-distance modifiers p. B241</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Sensory Control_5</name>
+						<cost type="points">35</cost>
+						<affects>total</affects>
+						<notes>No penalty for range</notes>
+					</modifier>
+					<reference>PSI62</reference>
+					<notes>Control ability.  Your target hallucinates.</notes>
+					<categories>
+						<category>Control</category>
+						<category>Psionics</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Suggestion</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Suggestion_1</name>
+						<cost type="points">10</cost>
+						<affects>total</affects>
+						<notes>Skin-to-skin contact</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Suggestion_2</name>
+						<cost type="points">20</cost>
+						<affects>total</affects>
+						<notes>Any touch will suffice</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Suggestion_3</name>
+						<cost type="points">30</cost>
+						<affects>total</affects>
+						<notes>Suggestion at range; -1 penalty/yard distance</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Suggestion_4</name>
+						<reference>B550</reference>
+						<cost type="points">35</cost>
+						<affects>total</affects>
+						<notes>Use range penalties p. B550</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Suggestion_5</name>
+						<reference>B241</reference>
+						<cost type="points">50</cost>
+						<affects>total</affects>
+						<notes>Use long-distance modifiers p. B241</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Suggestion_6</name>
+						<reference>B241</reference>
+						<cost type="points">75</cost>
+						<affects>total</affects>
+						<notes>Use long-distance modifiers p. B241</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Suggestion_7</name>
+						<cost type="points">100</cost>
+						<affects>total</affects>
+						<notes>No penalty for range</notes>
+					</modifier>
+					<reference>PSI63</reference>
+					<notes>Control ability.  You can send telepathic commands to a subject.</notes>
+					<categories>
+						<category>Control</category>
+						<category>Psionics</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Telecontrol</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<base_points>15</base_points>
+					<points_per_level>15</points_per_level>
+					<reference>PSI64</reference>
+					<notes>Control ability.  You can completely take over the body of a human being. </notes>
+					<categories>
+						<category>Control</category>
+						<category>Psionics</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+			</advantage_container>
+			<advantage version="3">
+				<name>Deep Study</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI63</reference>
+				<categories>
+					<category>Communication</category>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Telepathy</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>I Know What You Mean</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI63</reference>
+				<categories>
+					<category>Communication</category>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Telepathy</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Intimidation Factor</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI63</reference>
+				<categories>
+					<category>Offense</category>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Telepathy</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Mindlink</name>
+				<type>Mental</type>
+				<modifier version="1" enabled="no">
+					<name>Single person</name>
+					<reference>B70</reference>
+					<cost type="points">5</cost>
+					<affects>total</affects>
+					<notes>@Who@</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>2-9 people</name>
+					<reference>B70</reference>
+					<cost type="points">10</cost>
+					<affects>total</affects>
+					<notes>@Who@</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>10-99 people</name>
+					<reference>B70</reference>
+					<cost type="points">20</cost>
+					<affects>total</affects>
+					<notes>@Who@</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>100-999 people</name>
+					<reference>B70</reference>
+					<cost type="points">30</cost>
+					<affects>total</affects>
+					<notes>@Who@</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>1000-9999 people</name>
+					<reference>B70</reference>
+					<cost type="points">40</cost>
+					<affects>total</affects>
+					<notes>@Who@</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>10000-99999 people</name>
+					<reference>B70</reference>
+					<cost type="points">50</cost>
+					<affects>total</affects>
+					<notes>@Who@</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Broadcast</name>
+					<reference>B91</reference>
+					<cost type="percentage">50</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Cybernetic</name>
+					<reference>B69</reference>
+					<cost type="percentage">50</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Sensory</name>
+					<reference>B69</reference>
+					<cost type="percentage">20</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Universal</name>
+					<reference>B69</reference>
+					<cost type="percentage">50</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Video</name>
+					<reference>B91</reference>
+					<cost type="percentage">40</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Cybernetic Only</name>
+					<reference>B70</reference>
+					<cost type="percentage">-50</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Racial</name>
+					<reference>B70</reference>
+					<cost type="percentage">-20</cost>
+					<affects>total</affects>
+					<notes>@Race@</notes>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Sensory Only</name>
+					<reference>B70</reference>
+					<cost type="percentage">-20</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Telecommunication</name>
+					<reference>B70</reference>
+					<cost type="percentage">-20</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Vague</name>
+					<reference>B91</reference>
+					<cost type="percentage">-50</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1">
+					<name>Telepathy</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI67</reference>
+				<categories>
+					<category>Communication</category>
+					<category>Psionics</category>
+					<category>Telepathy</category>
+				</categories>
+			</advantage>
+			<advantage_container version="3" open="yes">
+				<name>Offense</name>
+				<reference>PSI64</reference>
+				<notes>Branch of Telepathy</notes>
 				<categories>
 					<category>Offense</category>
 					<category>Psionics</category>
 					<category>Telepathy</category>
 				</categories>
+				<advantage version="3">
+					<name>Instill Fear</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<base_points>15</base_points>
+					<points_per_level>3</points_per_level>
+					<reference>PSI64</reference>
+					<notes>Offense ability. Project fear and terror into someone's heart.</notes>
+					<categories>
+						<category>Offense</category>
+						<category>Psionics</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Mental Blow</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Mental Blow_1</name>
+						<cost type="points">17</cost>
+						<affects>total</affects>
+						<notes>Skin-to-skin contact</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Mental Blow_2</name>
+						<cost type="points">20</cost>
+						<affects>total</affects>
+						<notes>Any touch will suffice</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Mental Blow_3</name>
+						<cost type="points">23</cost>
+						<affects>total</affects>
+						<notes>Mental Blow at range; -1 penalty/yard distance</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Mental Blow_4</name>
+						<reference>B550</reference>
+						<cost type="points">28</cost>
+						<affects>total</affects>
+						<notes>Use range penalties p. B550</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Mental Blow_5</name>
+						<reference>B241</reference>
+						<cost type="points">33</cost>
+						<affects>total</affects>
+						<notes>Use long-distance modifiers p. B241</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Mental Blow_6</name>
+						<cost type="points">38</cost>
+						<affects>total</affects>
+						<notes>No penalty for range</notes>
+					</modifier>
+					<reference>PSI65</reference>
+					<notes>Offense ability. Overload someone's brain with a psychic attack. </notes>
+					<categories>
+						<category>Communication</category>
+						<category>Psionics</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Mental Stab</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Mental Stab_1</name>
+						<cost type="points">33</cost>
+						<affects>total</affects>
+						<notes>Skin-to-skin contact</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Mental Stab_2</name>
+						<cost type="points">43</cost>
+						<affects>total</affects>
+						<notes>Any touch will suffice</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Mental Stab_3</name>
+						<cost type="points">52</cost>
+						<affects>total</affects>
+						<notes>Mental Blow at range; -1 penalty/yard distance</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Mental Stab_4</name>
+						<reference>B550</reference>
+						<cost type="points">69</cost>
+						<affects>total</affects>
+						<notes>Use range penalties p. B550</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Mental Stab_5</name>
+						<reference>B241</reference>
+						<cost type="points">85</cost>
+						<affects>total</affects>
+						<notes>Use long-distance modifiers p. B241</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Mental Stab_6</name>
+						<cost type="points">101</cost>
+						<affects>total</affects>
+						<notes>No penalty for range</notes>
+					</modifier>
+					<reference>PSI65</reference>
+					<notes>Offense ability. Psychically attack someone's brain, doing real damage.</notes>
+					<categories>
+						<category>Communication</category>
+						<category>Psionics</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Sleep (Telepathy)</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Sleep_1</name>
+						<cost type="points">25</cost>
+						<affects>total</affects>
+						<notes>Skin-to-skin contact.</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Sleep_2</name>
+						<cost type="points">28</cost>
+						<affects>total</affects>
+						<notes>Any touch will suffice.</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Sleep_3</name>
+						<cost type="points">31</cost>
+						<affects>total</affects>
+						<notes>Can use sleep at range; -1 penalty/yard distance</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Sleep_4</name>
+						<reference>B550</reference>
+						<cost type="points">36</cost>
+						<affects>total</affects>
+						<notes>Use range penalties p. B550</notes>
+					</modifier>
+					<reference>PSI66</reference>
+					<notes>Offense ability. You safely put someone to sleep.</notes>
+					<categories>
+						<category>Offense</category>
+						<category>Psionics</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+			</advantage_container>
+			<advantage version="3">
+				<name>Ping</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI63</reference>
+				<categories>
+					<category>Communication</category>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Telepathy</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Protected Power (Telepathy)</name>
+				<type>Mental</type>
+				<modifier version="1">
+					<name>Telepathy</name>
+					<cost type="percentage">-10</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI67</reference>
+				<categories>
+					<category>Communication</category>
+					<category>Psionics</category>
+					<category>Telepathy</category>
+				</categories>
+			</advantage>
+			<advantage_container version="3" open="yes">
+				<name>Sense and Defense</name>
+				<reference>PSI66</reference>
+				<notes>Branch of Telepathy</notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Sense and Defense</category>
+					<category>Telepathy</category>
+				</categories>
+				<advantage version="3">
+					<name>Mind Clouding</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<points_per_level>6</points_per_level>
+					<reference>PSI66</reference>
+					<notes>Sense and defense ability. People don't perceive your presence. </notes>
+					<categories>
+						<category>Psionics</category>
+						<category>Sense and Defense</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Mind Shield</name>
+					<type>Mental</type>
+					<levels>1</levels>
+					<points_per_level>4</points_per_level>
+					<modifier version="1" enabled="no">
+						<name>Feedback</name>
+						<reference>PSI67</reference>
+						<cost type="percentage">-25</cost>
+						<affects>total</affects>
+					</modifier>
+					<reference>PSI66</reference>
+					<notes>Sense and defense ability.You have a mental shield protecting you. </notes>
+					<categories>
+						<category>Psionics</category>
+						<category>Sense and Defense</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Telepathy Sense</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Telepathy Sense_1</name>
+						<cost type="points">4</cost>
+						<affects>total</affects>
+						<notes>Vague sense</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telepathy Sense_2</name>
+						<cost type="points">7</cost>
+						<affects>total</affects>
+						<notes>Gives direction of nearest telepathy use</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telepathy Sense_3</name>
+						<cost type="points">11</cost>
+						<affects>total</affects>
+						<notes>Direction and distance to nearest telepathy usage</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telepathy Sense_4</name>
+						<cost type="points">16</cost>
+						<affects>total</affects>
+						<notes>Direction, distance, and ability of nearest telepathy usage</notes>
+					</modifier>
+					<reference>PSI67</reference>
+					<notes>Sense and defense ability. You can sense nearby telepathic activity. </notes>
+					<categories>
+						<category>Psionics</category>
+						<category>Sense and Defense</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+				<advantage version="3">
+					<name>Telescan</name>
+					<type>Mental</type>
+					<modifier version="1" enabled="no">
+						<name>Telescan_1</name>
+						<reference>B550</reference>
+						<cost type="points">11</cost>
+						<affects>total</affects>
+						<notes>Range penalties p. B550</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telescan_2</name>
+						<reference>B550</reference>
+						<cost type="points">15</cost>
+						<affects>total</affects>
+						<notes>Range penalties P. B550</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telescan_3</name>
+						<reference>B241</reference>
+						<cost type="points">20</cost>
+						<affects>total</affects>
+						<notes>Long-distance modifiers p. B241</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telescan_4</name>
+						<reference>B241</reference>
+						<cost type="points">25</cost>
+						<affects>total</affects>
+						<notes>Long-distance modifiers p. B241</notes>
+					</modifier>
+					<modifier version="1" enabled="no">
+						<name>Telescan_5</name>
+						<cost type="points">30</cost>
+						<affects>total</affects>
+						<notes>No range penalties</notes>
+					</modifier>
+					<reference>PSI67</reference>
+					<notes>Sense and defense ability. You can search for minds you know. </notes>
+					<categories>
+						<category>Psionics</category>
+						<category>Sense and Defense</category>
+						<category>Telepathy</category>
+					</categories>
+				</advantage>
+			</advantage_container>
+			<advantage version="3">
+				<name>Synchronize</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI63</reference>
+				<categories>
+					<category>Communication</category>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Telepathy</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Tactical Reading</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI63</reference>
+				<categories>
+					<category>Communication</category>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Telepathy</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Telepathy Talent</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>5</points_per_level>
+				<reference>PSI19</reference>
+				<categories>
+					<category>Communication</category>
+					<category>Control</category>
+					<category>Offense</category>
+					<category>Power</category>
+					<category>Sense and Defense</category>
+					<category>Telepathy</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">Borrow Skill</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Emotion Sense</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Telereceive</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Telesend</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Aspect</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Mental Surgery</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Mind Swap</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Mindwipe</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Sensory Control</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Suggestion</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Telecontrol</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Instill Fear</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Mental Blow</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Mental Stab</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Sleep (Telepathy)</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Mind Clouding</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Mind Shield</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Telepathy Sense</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Telescan</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Crippling Blow</name>
+					<specialization compare="contains">Telepathy</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Deafening Display</name>
+					<specialization compare="contains">Telepathy</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Drugged Weapon</name>
+					<specialization compare="contains">Telepathy</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Fatiguing Strike</name>
+					<specialization compare="contains">Telepathy</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Project Blow</name>
+					<specialization compare="contains">Telepathy</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Restorative Armor</name>
+					<specialization compare="contains">Telepathy</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Stealthy Attack</name>
+					<specialization compare="contains">Telepathy</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Stupefying Blow</name>
+					<specialization compare="contains">Telepathy</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Subtle Defense</name>
+					<specialization compare="contains">Telepathy</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Sudden Death</name>
+					<specialization compare="contains">Telepathy</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Thunderous Defense</name>
+					<specialization compare="contains">Telepathy</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<prereq_list all="no">
+					<advantage_prereq has="no">
+						<name compare="is">Offense Talent</name>
+						<notes compare="is anything"></notes>
+						<level compare="at least">1</level>
+					</advantage_prereq>
+					<advantage_prereq has="no">
+						<name compare="is">Control Talent</name>
+						<notes compare="is anything"></notes>
+						<level compare="at least">1</level>
+					</advantage_prereq>
+					<advantage_prereq has="no">
+						<name compare="is">Sense and Defense Talent</name>
+						<notes compare="is anything"></notes>
+						<level compare="at least">1</level>
+					</advantage_prereq>
+					<advantage_prereq has="no">
+						<name compare="is">Communication Talent</name>
+						<notes compare="is anything"></notes>
+						<level compare="at least">1</level>
+					</advantage_prereq>
+				</prereq_list>
 			</advantage>
 		</advantage_container>
-		<advantage version="3">
-			<name>Ping</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI63</reference>
-			<categories>
-				<category>Communication</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Telepathy</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Protected Power (Telepathy)</name>
-			<type>Mental</type>
-			<modifier version="1">
-				<name>Telepathy</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI67</reference>
-			<categories>
-				<category>Communication</category>
-				<category>Psionics</category>
-				<category>Telepathy</category>
-			</categories>
-		</advantage>
-		<advantage_container version="3" open="yes">
-			<name>Sense and Defense</name>
-			<reference>PSI66</reference>
-			<notes>Branch of Telepathy</notes>
+		<advantage_container version="3" open="no">
+			<name>Teleportation</name>
+			<reference>PSI68</reference>
 			<categories>
 				<category>Psionics</category>
-				<category>Sense and Defense</category>
-				<category>Telepathy</category>
+				<category>Teleportation</category>
 			</categories>
 			<advantage version="3">
-				<name>Mind Clouding</name>
+				<name>Autoteleport</name>
 				<type>Mental</type>
-				<levels>1</levels>
-				<points_per_level>6</points_per_level>
-				<reference>PSI66</reference>
-				<notes>Sense and defense ability. People don't perceive your presence. </notes>
-				<categories>
-					<category>Psionics</category>
-					<category>Sense and Defense</category>
-					<category>Telepathy</category>
-				</categories>
-			</advantage>
-			<advantage version="3">
-				<name>Mind Shield</name>
-				<type>Mental</type>
-				<levels>1</levels>
-				<points_per_level>4</points_per_level>
 				<modifier version="1" enabled="no">
-					<name>Feedback</name>
-					<cost type="percentage">-25</cost>
+					<name>Autoteleport_1</name>
+					<cost type="points">20</cost>
 					<affects>total</affects>
-					<reference>PSI67</reference>
 				</modifier>
-				<reference>PSI66</reference>
-				<notes>Sense and defense ability.You have a mental shield protecting you. </notes>
+				<modifier version="1" enabled="no">
+					<name>Autoteleport_2</name>
+					<cost type="points">30</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Autoteleport_3</name>
+					<cost type="points">40</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Autoteleport_4</name>
+					<cost type="points">50</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Autoteleport_5</name>
+					<cost type="points">55</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Autoteleport_6</name>
+					<cost type="points">60</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Autoteleport_7</name>
+					<cost type="points">65</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Autoteleport_8</name>
+					<cost type="points">70</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Autoteleport_9</name>
+					<cost type="points">75</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Autoteleport_10</name>
+					<cost type="points">80</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Autoteleport_11</name>
+					<cost type="points">85</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Autoteleport_12</name>
+					<cost type="points">90</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Autoteleport_13</name>
+					<cost type="points">95</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Autoteleport_14</name>
+					<cost type="points">100</cost>
+					<affects>total</affects>
+				</modifier>
+				<reference>PSI68</reference>
+				<notes>Teleportation ability. Instantly travel over great distances. </notes>
 				<categories>
 					<category>Psionics</category>
-					<category>Sense and Defense</category>
-					<category>Telepathy</category>
+					<category>Teleportation</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Telepathy Sense</name>
+				<name>Bamf</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI69</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Teleportation</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Castling</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI69</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Teleportation</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Coin Trick</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI69</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Teleportation</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Combat Teleport</name>
+				<type>Mental</type>
+				<base_points>40</base_points>
+				<modifier version="1" enabled="no">
+					<name>Touch only</name>
+					<cost type="points">-11</cost>
+					<affects>total</affects>
+					<notes>You must have skin-to-skin contact to exoteleport the subject. </notes>
+				</modifier>
+				<reference>PSI68</reference>
+				<notes>Teleportation ability. Teleport to dodge attacks. </notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Teleportation</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Combat Teleport (Have Autoteleport)</name>
+				<type>Mental</type>
+				<base_points>15</base_points>
+				<reference>PSI68</reference>
+				<notes>Teleportation ability. Teleport to dodge attacks. </notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Teleportation</category>
+				</categories>
+				<prereq_list all="yes">
+					<advantage_prereq has="yes">
+						<name compare="is">Autoteleport</name>
+						<notes compare="contains">_</notes>
+					</advantage_prereq>
+				</prereq_list>
+			</advantage>
+			<advantage version="3">
+				<name>Exo-Draw</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI69</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Teleportation</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Exoteleport</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<base_points>41</base_points>
+				<points_per_level>5</points_per_level>
+				<modifier version="1" enabled="no">
+					<name>Touch only</name>
+					<cost type="points">-11</cost>
+					<affects>total</affects>
+					<notes>You must have skin-to-skin contact to exoteleport the subject. </notes>
+				</modifier>
+				<reference>PSI69</reference>
+				<notes>Teleportation ability. Teleport other people or objects. </notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Teleportation</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Expulsion</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI69</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Teleportation</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Inertia Control</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI69</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Teleportation</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Innerportation</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>9</points_per_level>
+				<ranged_weapon>
+					<damage type="imp" base="1d-2"/>
+					<usage>Innerportation</usage>
+					<range>B550</range>
+					<rate_of_fire>1</rate_of_fire>
+					<default>
+						<type>Will</type>
+						<modifier>-6</modifier>
+					</default>
+					<default>
+						<type>Skill</type>
+						<name>Innerportation</name>
+						<modifier>0</modifier>
+					</default>
+				</ranged_weapon>
+				<reference>PSI70</reference>
+				<notes>Teleportation ability. Damage someone by teleporting away portions of their body.</notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Teleportation</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Portersense</name>
 				<type>Mental</type>
 				<modifier version="1" enabled="no">
-					<name>Telepathy Sense_1</name>
+					<name>Portersense_1</name>
 					<cost type="points">4</cost>
 					<affects>total</affects>
 					<notes>Vague sense</notes>
 				</modifier>
 				<modifier version="1" enabled="no">
-					<name>Telepathy Sense_2</name>
+					<name>Portersense_2</name>
 					<cost type="points">7</cost>
 					<affects>total</affects>
-					<notes>Gives direction of nearest telepathy use</notes>
+					<notes>You know the direction to the teleportation activity. </notes>
 				</modifier>
 				<modifier version="1" enabled="no">
-					<name>Telepathy Sense_3</name>
+					<name>Portersense_3</name>
 					<cost type="points">11</cost>
 					<affects>total</affects>
-					<notes>Direction and distance to nearest telepathy usage</notes>
+					<notes>You know the direction and distance to the teleportation activity. </notes>
 				</modifier>
 				<modifier version="1" enabled="no">
-					<name>Telepathy Sense_4</name>
+					<name>Portersense_4</name>
 					<cost type="points">16</cost>
 					<affects>total</affects>
-					<notes>Direction, distance, and ability of nearest telepathy usage</notes>
+					<notes>Passively know the direction and distance to the teleportation activity. </notes>
 				</modifier>
-				<reference>PSI67</reference>
-				<notes>Sense and defense ability. You can sense nearby telepathic activity. </notes>
+				<reference>PSI71</reference>
+				<notes>Teleportation ability. You can detect teleportation.</notes>
 				<categories>
 					<category>Psionics</category>
-					<category>Sense and Defense</category>
-					<category>Telepathy</category>
+					<category>Teleportation</category>
 				</categories>
 			</advantage>
 			<advantage version="3">
-				<name>Telescan</name>
+				<name>Protected Power (Teleportation)</name>
 				<type>Mental</type>
-				<modifier version="1" enabled="no">
-					<name>Telescan_1</name>
-					<cost type="points">11</cost>
+				<base_points>5</base_points>
+				<modifier version="1">
+					<name>Teleportation</name>
+					<cost type="percentage">-10</cost>
 					<affects>total</affects>
-					<reference>B550</reference>
-					<notes>Range penalties p. B550</notes>
 				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telescan_2</name>
-					<cost type="points">15</cost>
-					<affects>total</affects>
-					<reference>B550</reference>
-					<notes>Range penalties P. B550</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telescan_3</name>
-					<cost type="points">20</cost>
-					<affects>total</affects>
-					<reference>B241</reference>
-					<notes>Long-distance modifiers p. B241</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telescan_4</name>
-					<cost type="points">25</cost>
-					<affects>total</affects>
-					<reference>B241</reference>
-					<notes>Long-distance modifiers p. B241</notes>
-				</modifier>
-				<modifier version="1" enabled="no">
-					<name>Telescan_5</name>
-					<cost type="points">30</cost>
-					<affects>total</affects>
-					<notes>No range penalties</notes>
-				</modifier>
-				<reference>PSI67</reference>
-				<notes>Sense and defense ability. You can search for minds you know. </notes>
+				<reference>PSI71</reference>
 				<categories>
 					<category>Psionics</category>
-					<category>Sense and Defense</category>
-					<category>Telepathy</category>
+					<category>Teleportation</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>RL Exoteleport</name>
+				<type>Mental</type>
+				<modifier version="1" enabled="no">
+					<name>Exoteleport_1</name>
+					<cost type="points">45</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Exoteleport_2</name>
+					<cost type="points">55</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Exoteleport_3</name>
+					<cost type="points">65</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Exoteleport_4</name>
+					<cost type="points">75</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Exoteleport_5</name>
+					<cost type="points">80</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Exoteleport_6</name>
+					<cost type="points">85</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Exoteleport_7</name>
+					<cost type="points">90</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Exoteleport_8</name>
+					<cost type="points">95</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Exoteleport_9</name>
+					<cost type="points">100</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Exoteleport_10</name>
+					<cost type="points">105</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Exoteleport_11</name>
+					<cost type="points">110</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Exoteleport_12</name>
+					<cost type="points">115</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Exoteleport_13</name>
+					<cost type="points">120</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Exoteleport_14</name>
+					<cost type="points">125</cost>
+					<affects>total</affects>
+				</modifier>
+				<modifier version="1" enabled="no">
+					<name>Touch only</name>
+					<cost type="points">-11</cost>
+					<affects>total</affects>
+					<notes>You must have skin-to-skin contact to RL exoteleport the subject. </notes>
+				</modifier>
+				<reference>PSI70</reference>
+				<notes>Teleportation ability.Teleport other people or objects.  </notes>
+				<categories>
+					<category>Psionics</category>
+					<category>Teleportation</category>
+				</categories>
+			</advantage>
+			<advantage version="3">
+				<name>Teleportation Talent</name>
+				<type>Mental</type>
+				<levels>1</levels>
+				<points_per_level>5</points_per_level>
+				<reference>PSI19</reference>
+				<categories>
+					<category>Power</category>
+					<category>Teleportation</category>
+				</categories>
+				<skill_bonus>
+					<name compare="is">Autoteleport</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Exoteleport</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Innerportation</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Portersense</name>
+					<specialization compare="is anything"></specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Conic Blast</name>
+					<specialization compare="contains">Teleportation</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Multi-Shot</name>
+					<specialization compare="contains">Teleportation</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Penetrating Strike</name>
+					<specialization compare="contains">Teleportation</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Project Blow</name>
+					<specialization compare="contains">Teleportation</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Shattershot</name>
+					<specialization compare="contains">Teleportation</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Shockwave</name>
+					<specialization compare="contains">Teleportation</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+				<skill_bonus>
+					<name compare="is">Telescoping Weapon</name>
+					<specialization compare="contains">Teleportation</specialization>
+					<category compare="is anything"></category>
+					<amount per_level="yes">1</amount>
+				</skill_bonus>
+			</advantage>
+			<advantage version="3">
+				<name>That Extra Inch</name>
+				<type>Mental</type>
+				<base_points>1</base_points>
+				<reference>PSI69</reference>
+				<categories>
+					<category>Perk</category>
+					<category>Psionics</category>
+					<category>Teleportation</category>
 				</categories>
 			</advantage>
 		</advantage_container>
-		<advantage version="3">
-			<name>Synchronize</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI63</reference>
-			<categories>
-				<category>Communication</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Telepathy</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Tactical Reading</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI63</reference>
-			<categories>
-				<category>Communication</category>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Telepathy</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Telepathy Talent</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>5</points_per_level>
-			<reference>PSI19</reference>
-			<categories>
-				<category>Communication</category>
-				<category>Control</category>
-				<category>Offense</category>
-				<category>Power</category>
-				<category>Sense and Defense</category>
-				<category>Telepathy</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Borrow Skill</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Emotion Sense</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Telereceive</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Telesend</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Aspect</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Mental Surgery</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Mind Swap</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Mindwipe</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Sensory Control</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Suggestion</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Telecontrol</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Instill Fear</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Mental Blow</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Mental Stab</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Sleep (Telepathy)</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Mind Clouding</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Mind Shield</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Telepathy Sense</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Telescan</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Crippling Blow</name>
-				<specialization compare="contains">Telepathy</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Deafening Display</name>
-				<specialization compare="contains">Telepathy</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Drugged Weapon</name>
-				<specialization compare="contains">Telepathy</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Fatiguing Strike</name>
-				<specialization compare="contains">Telepathy</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Project Blow</name>
-				<specialization compare="contains">Telepathy</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Restorative Armor</name>
-				<specialization compare="contains">Telepathy</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Stealthy Attack</name>
-				<specialization compare="contains">Telepathy</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Stupefying Blow</name>
-				<specialization compare="contains">Telepathy</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Subtle Defense</name>
-				<specialization compare="contains">Telepathy</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Sudden Death</name>
-				<specialization compare="contains">Telepathy</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Thunderous Defense</name>
-				<specialization compare="contains">Telepathy</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<prereq_list all="no">
-				<advantage_prereq has="no">
-					<name compare="is">Offense Talent</name>
-					<notes compare="is anything"></notes>
-					<level compare="at least">1</level>
-				</advantage_prereq>
-				<advantage_prereq has="no">
-					<name compare="is">Control Talent</name>
-					<notes compare="is anything"></notes>
-					<level compare="at least">1</level>
-				</advantage_prereq>
-				<advantage_prereq has="no">
-					<name compare="is">Sense and Defense Talent</name>
-					<notes compare="is anything"></notes>
-					<level compare="at least">1</level>
-				</advantage_prereq>
-				<advantage_prereq has="no">
-					<name compare="is">Communication Talent</name>
-					<notes compare="is anything"></notes>
-					<level compare="at least">1</level>
-				</advantage_prereq>
-			</prereq_list>
-		</advantage>
-	</advantage_container>
-	<advantage_container version="3" open="yes">
-		<name>Teleportation</name>
-		<reference>PSI68</reference>
-		<categories>
-			<category>Psionics</category>
-			<category>Teleportation</category>
-		</categories>
-		<advantage version="3">
-			<name>Autoteleport</name>
-			<type>Mental</type>
-			<modifier version="1" enabled="no">
-				<name>Autoteleport_1</name>
-				<cost type="points">20</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Autoteleport_2</name>
-				<cost type="points">30</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Autoteleport_3</name>
-				<cost type="points">40</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Autoteleport_4</name>
-				<cost type="points">50</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Autoteleport_5</name>
-				<cost type="points">55</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Autoteleport_6</name>
-				<cost type="points">60</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Autoteleport_7</name>
-				<cost type="points">65</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Autoteleport_8</name>
-				<cost type="points">70</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Autoteleport_9</name>
-				<cost type="points">75</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Autoteleport_10</name>
-				<cost type="points">80</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Autoteleport_11</name>
-				<cost type="points">85</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Autoteleport_12</name>
-				<cost type="points">90</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Autoteleport_13</name>
-				<cost type="points">95</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Autoteleport_14</name>
-				<cost type="points">100</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI68</reference>
-			<notes>Teleportation ability. Instantly travel over great distances. </notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Teleportation</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Bamf</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI69</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Teleportation</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Castling</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI69</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Teleportation</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Coin Trick</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI69</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Teleportation</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Combat Teleport</name>
-			<type>Mental</type>
-			<base_points>40</base_points>
-			<modifier version="1" enabled="no">
-				<name>Touch only</name>
-				<cost type="points">-11</cost>
-				<affects>total</affects>
-				<notes>You must have skin-to-skin contact to exoteleport the subject. </notes>
-			</modifier>
-			<reference>PSI68</reference>
-			<notes>Teleportation ability. Teleport to dodge attacks. </notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Teleportation</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Combat Teleport (Have Autoteleport)</name>
-			<type>Mental</type>
-			<base_points>15</base_points>
-			<reference>PSI68</reference>
-			<notes>Teleportation ability. Teleport to dodge attacks. </notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Teleportation</category>
-			</categories>
-			<prereq_list all="yes">
-				<advantage_prereq has="yes">
-					<name compare="is">Autoteleport</name>
-					<notes compare="contains">_</notes>
-				</advantage_prereq>
-			</prereq_list>
-		</advantage>
-		<advantage version="3">
-			<name>Exo-Draw</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI69</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Teleportation</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Exoteleport</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<base_points>41</base_points>
-			<points_per_level>5</points_per_level>
-			<modifier version="1" enabled="no">
-				<name>Touch only</name>
-				<cost type="points">-11</cost>
-				<affects>total</affects>
-				<notes>You must have skin-to-skin contact to exoteleport the subject. </notes>
-			</modifier>
-			<reference>PSI69</reference>
-			<notes>Teleportation ability. Teleport other people or objects. </notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Teleportation</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Expulsion</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI69</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Teleportation</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Inertia Control</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI69</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Teleportation</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Innerportation</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>9</points_per_level>
-			<ranged_weapon>
-				<damage type="imp" base="1d-2"/>
-				<usage>Innerportation</usage>
-				<range>B550</range>
-				<rate_of_fire>1</rate_of_fire>
-				<default>
-					<type>Will</type>
-					<modifier>-6</modifier>
-				</default>
-				<default>
-					<type>Skill</type>
-					<name>Innerportation</name>
-					<modifier>0</modifier>
-				</default>
-			</ranged_weapon>
-			<reference>PSI70</reference>
-			<notes>Teleportation ability. Damage someone by teleporting away portions of their body.</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Teleportation</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Portersense</name>
-			<type>Mental</type>
-			<modifier version="1" enabled="no">
-				<name>Portersense_1</name>
-				<cost type="points">4</cost>
-				<affects>total</affects>
-				<notes>Vague sense</notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Portersense_2</name>
-				<cost type="points">7</cost>
-				<affects>total</affects>
-				<notes>You know the direction to the teleportation activity. </notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Portersense_3</name>
-				<cost type="points">11</cost>
-				<affects>total</affects>
-				<notes>You know the direction and distance to the teleportation activity. </notes>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Portersense_4</name>
-				<cost type="points">16</cost>
-				<affects>total</affects>
-				<notes>Passively know the direction and distance to the teleportation activity. </notes>
-			</modifier>
-			<reference>PSI71</reference>
-			<notes>Teleportation ability. You can detect teleportation.</notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Teleportation</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Protected Power (Teleportation)</name>
-			<type>Mental</type>
-			<base_points>5</base_points>
-			<modifier version="1">
-				<name>Teleportation</name>
-				<cost type="percentage">-10</cost>
-				<affects>total</affects>
-			</modifier>
-			<reference>PSI71</reference>
-			<categories>
-				<category>Psionics</category>
-				<category>Teleportation</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>RL Exoteleport</name>
-			<type>Mental</type>
-			<modifier version="1" enabled="no">
-				<name>Exoteleport_1</name>
-				<cost type="points">45</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Exoteleport_2</name>
-				<cost type="points">55</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Exoteleport_3</name>
-				<cost type="points">65</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Exoteleport_4</name>
-				<cost type="points">75</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Exoteleport_5</name>
-				<cost type="points">80</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Exoteleport_6</name>
-				<cost type="points">85</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Exoteleport_7</name>
-				<cost type="points">90</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Exoteleport_8</name>
-				<cost type="points">95</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Exoteleport_9</name>
-				<cost type="points">100</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Exoteleport_10</name>
-				<cost type="points">105</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Exoteleport_11</name>
-				<cost type="points">110</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Exoteleport_12</name>
-				<cost type="points">115</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Exoteleport_13</name>
-				<cost type="points">120</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Exoteleport_14</name>
-				<cost type="points">125</cost>
-				<affects>total</affects>
-			</modifier>
-			<modifier version="1" enabled="no">
-				<name>Touch only</name>
-				<cost type="points">-11</cost>
-				<affects>total</affects>
-				<notes>You must have skin-to-skin contact to RL exoteleport the subject. </notes>
-			</modifier>
-			<reference>PSI70</reference>
-			<notes>Teleportation ability.Teleport other people or objects.  </notes>
-			<categories>
-				<category>Psionics</category>
-				<category>Teleportation</category>
-			</categories>
-		</advantage>
-		<advantage version="3">
-			<name>Teleportation Talent</name>
-			<type>Mental</type>
-			<levels>1</levels>
-			<points_per_level>5</points_per_level>
-			<reference>PSI19</reference>
-			<categories>
-				<category>Power</category>
-				<category>Teleportation</category>
-			</categories>
-			<skill_bonus>
-				<name compare="is">Autoteleport</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Exoteleport</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Innerportation</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Portersense</name>
-				<specialization compare="is anything"></specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Conic Blast</name>
-				<specialization compare="contains">Teleportation</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Multi-Shot</name>
-				<specialization compare="contains">Teleportation</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Penetrating Strike</name>
-				<specialization compare="contains">Teleportation</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Project Blow</name>
-				<specialization compare="contains">Teleportation</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Shattershot</name>
-				<specialization compare="contains">Teleportation</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Shockwave</name>
-				<specialization compare="contains">Teleportation</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-			<skill_bonus>
-				<name compare="is">Telescoping Weapon</name>
-				<specialization compare="contains">Teleportation</specialization>
-				<category compare="is anything"></category>
-				<amount per_level="yes">1</amount>
-			</skill_bonus>
-		</advantage>
-		<advantage version="3">
-			<name>That Extra Inch</name>
-			<type>Mental</type>
-			<base_points>1</base_points>
-			<reference>PSI69</reference>
-			<categories>
-				<category>Perk</category>
-				<category>Psionics</category>
-				<category>Teleportation</category>
-			</categories>
-		</advantage>
 	</advantage_container>
 </advantage_list>

--- a/Library/Psionics/Psionics Enhancement Modifiers.adm
+++ b/Library/Psionics/Psionics Enhancement Modifiers.adm
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="US-ASCII" ?>
+<modifier_list id="b25a52af-8edf-47b6-8388-5003e0f6468d" version="1">
+	<modifier version="1">
+		<name>Can Carry Objects </name>
+		<reference>PSI19</reference>
+		<cost type="percentage">150</cost>
+		<affects>total</affects>
+		<notes>Extra Heavy Encumberance</notes>
+	</modifier>
+	<modifier version="1">
+		<name>Hazard: Heat</name>
+		<reference>PSI19</reference>
+		<cost type="percentage">20</cost>
+		<affects>total</affects>
+	</modifier>
+	<modifier version="1">
+		<name>Glamour</name>
+		<reference>PSI20</reference>
+		<cost type="percentage">0</cost>
+		<affects>total</affects>
+	</modifier>
+	<modifier version="1">
+		<name>Increased Range, Line of Sight</name>
+		<reference>PSI20</reference>
+		<cost type="percentage">40</cost>
+		<affects>total</affects>
+		<notes>For 100 Yard Range abilities</notes>
+	</modifier>
+	<modifier version="1">
+		<name>Increased Range, Line of Sight</name>
+		<reference>PSI20</reference>
+		<cost type="percentage">70</cost>
+		<affects>total</affects>
+		<notes>For 10 Yard Range abilities</notes>
+	</modifier>
+	<modifier version="1">
+		<name>Low Psychic Signature</name>
+		<reference>PSI20</reference>
+		<cost type="percentage">5</cost>
+		<levels>1</levels>
+		<affects>total</affects>
+	</modifier>
+	<modifier version="1">
+		<name>Decreased Immunity</name>
+		<reference>PSI21</reference>
+		<cost type="percentage">50</cost>
+		<levels>1</levels>
+		<affects>total</affects>
+	</modifier>
+</modifier_list>

--- a/Library/Psionics/Psionics Limitation Modifiers.adm
+++ b/Library/Psionics/Psionics Limitation Modifiers.adm
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="US-ASCII" ?>
+<modifier_list id="1d60c76e-82ed-4ace-86d2-c16bb7ef6704" version="1">
+	<modifier version="1">
+		<name>Immediate Preparation Required</name>
+		<reference>PSI20</reference>
+		<cost type="percentage">-75</cost>
+		<affects>total</affects>
+		<notes>1 hour</notes>
+	</modifier>
+	<modifier version="1">
+		<name>Immediate Preparation Required</name>
+		<reference>PSI20</reference>
+		<cost type="percentage">-36</cost>
+		<affects>total</affects>
+		<notes>1 hour, Weakened without preparation</notes>
+	</modifier>
+	<modifier version="1">
+		<name>Immediate Preparation Required</name>
+		<reference>PSI20</reference>
+		<cost type="percentage">-30</cost>
+		<affects>total</affects>
+		<notes>1 minute</notes>
+	</modifier>
+	<modifier version="1">
+		<name>Immediate Preparation Required</name>
+		<reference>PSI20</reference>
+		<cost type="percentage">-15</cost>
+		<affects>total</affects>
+		<notes>1 minute, Weakened without preparation</notes>
+	</modifier>
+	<modifier version="1">
+		<name>Immediate Preparation Required</name>
+		<reference>PSI20</reference>
+		<cost type="percentage">-90</cost>
+		<affects>total</affects>
+		<notes>8 hours</notes>
+	</modifier>
+	<modifier version="1">
+		<name>Immediate Preparation Required</name>
+		<reference>PSI20</reference>
+		<cost type="percentage">-45</cost>
+		<affects>total</affects>
+		<notes>8 hours, Weakened without preparation</notes>
+	</modifier>
+	<modifier version="1">
+		<name>Preparation Required</name>
+		<reference>PSI20</reference>
+		<cost type="percentage">-45</cost>
+		<affects>total</affects>
+		<notes>10 minutes</notes>
+	</modifier>
+	<modifier version="1">
+		<name>Preparation Required</name>
+		<reference>PSI20</reference>
+		<cost type="percentage">-23</cost>
+		<affects>total</affects>
+		<notes>10 minutes, Weakened without preparation</notes>
+	</modifier>
+	<modifier version="1">
+		<name>Increased Immunity</name>
+		<reference>PSI21</reference>
+		<cost type="percentage">-10</cost>
+		<levels>1</levels>
+		<affects>total</affects>
+	</modifier>
+	<modifier version="1">
+		<name>Reduced Duration, 1/2</name>
+		<reference>PSI21</reference>
+		<cost type="percentage">-5</cost>
+		<affects>total</affects>
+	</modifier>
+	<modifier version="1">
+		<name>Reduced Duration, 1/3</name>
+		<reference>PSI21</reference>
+		<cost type="percentage">-10</cost>
+		<affects>total</affects>
+	</modifier>
+	<modifier version="1">
+		<name>Reduced Duration, 1/6</name>
+		<reference>PSI21</reference>
+		<cost type="percentage">-15</cost>
+		<affects>total</affects>
+	</modifier>
+	<modifier version="1">
+		<name>Reduced Duration, 1/10</name>
+		<reference>PSI21</reference>
+		<cost type="percentage">-20</cost>
+		<affects>total</affects>
+	</modifier>
+	<modifier version="1">
+		<name>Reduced Duration, 1/20</name>
+		<reference>PSI21</reference>
+		<cost type="percentage">-25</cost>
+		<affects>total</affects>
+	</modifier>
+	<modifier version="1">
+		<name>Reduced Duration, 1/30</name>
+		<reference>PSI21</reference>
+		<cost type="percentage">-30</cost>
+		<affects>total</affects>
+	</modifier>
+	<modifier version="1">
+		<name>Reduced Duration, 1/60</name>
+		<reference>PSI21</reference>
+		<cost type="percentage">-35</cost>
+		<affects>total</affects>
+	</modifier>
+	<modifier version="1">
+		<name>Weaponized, Bypass DR</name>
+		<reference>PSI21</reference>
+		<cost type="percentage">-50</cost>
+		<affects>total</affects>
+	</modifier>
+	<modifier version="1">
+		<name>Weaponized, DR Affects</name>
+		<reference>PSI21</reference>
+		<cost type="percentage">-80</cost>
+		<affects>total</affects>
+	</modifier>
+</modifier_list>


### PR DESCRIPTION
Includes:
Limitations and enhancements to Neutralize and static, applied to the advantages in both powers and Basic set. Also Hallucinations, to Illusions in Powers, and others.
Also includes new limitation and enhancement modifiers, as well as adding the new advantages from Psionic Powers to the Psionic Powers advantages library.

For some reason saving this has made GCS re-order the references in some cases, creating a lot of needless changes but I guess that's just the way it is.