### PR TITLE
Fix Errors in Basic Set Obsession, and Power Ups Perks

### DIFF
--- a/Library/Basic Set/Basic Set Advantages.adq
+++ b/Library/Basic Set/Basic Set Advantages.adq
@@ -11847,7 +11847,8 @@
 	</advantage>
 	<advantage version="3">
 		<name>Obsession</name>
-		<type>Physical</type>
+		<type>Mental</type>
+		<cr>12</cr>
 		<modifier version="1" enabled="no">
 			<name>Short term</name>
 			<reference>B146</reference>

--- a/Library/Power Ups/Power Ups Advantages.adq
+++ b/Library/Power Ups/Power Ups Advantages.adq
@@ -1,1264 +1,7 @@
 <?xml version="1.0" encoding="US-ASCII" ?>
 <advantage_list id="b8e36f7e-6c5f-444e-b5d3-2947516b2dff" version="1">
 	<advantage version="3">
-		<name>@Missing Disadvantage@</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>@Racial@ Gifts</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:12</reference>
-		<notes>May purchase @Traits@</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>@Skill@ based on @Stat@</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Acceleration Tolerance</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Acceleration Weakness</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Accent (@Language@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:12</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Accent (@Language@; @Region@)</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="is">Language: @Language@</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Accessory (@Accessory@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:10</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Aches and Pains</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Acrobatic Feints</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Admiration</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:25</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Affected by Magnetism</name>
-		<type>Physical, Exotic</type>
-		<base_points>-1</base_points>
-		<reference>PU6:12</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Air Jet</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:10</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Akimbo (@Weapon Skill@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Alcohol Intolerance</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:29</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Alcohol Tolerance</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Allergy (@Subject@)</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Amoral</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Anti-Talent (@Large@)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>-15</points_per_level>
-		<modifier version="1">
-			<name>Reaction Penalty</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>@Reaction Penalty@</notes>
-		</modifier>
-		<modifier version="1">
-			<name>Additional Drawback</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>@Additional Drawback@</notes>
-		</modifier>
-		<reference>PU3:19</reference>
-		<categories>
-			<category>Disadvantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">@skill01@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill02@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill03@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill04@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill05@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill06@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill07@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill08@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill09@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill10@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill11@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill12@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill13@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill14@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill15@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill16@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill17@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Anti-Talent (@Medium@)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>-10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Penalty</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>@Reaction Penalty@</notes>
-		</modifier>
-		<modifier version="1">
-			<name>Additional Drawback</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>@Additional Drawback@</notes>
-		</modifier>
-		<reference>PU3:19</reference>
-		<categories>
-			<category>Disadvantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">@skill01@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill02@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill03@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill04@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill05@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill06@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill07@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill08@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill09@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill10@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill11@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill12@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Anti-Talent (@Small@)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>-5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Penalty</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>@Reaction Penalty@</notes>
-		</modifier>
-		<modifier version="1">
-			<name>Additional Drawback</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>@Additional Drawback@</notes>
-		</modifier>
-		<reference>PU3:19</reference>
-		<categories>
-			<category>Disadvantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">@skill1@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill2@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill3@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill4@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill5@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill6@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Anti-Talent (Animal Foe)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>-5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Penalty</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>All animals, all the time</notes>
-		</modifier>
-		<modifier version="1">
-			<name>Additional Drawback</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Penalty to evaluate animals</notes>
-		</modifier>
-		<reference>PU3:20</reference>
-		<categories>
-			<category>Disadvantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Animal Handling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Falconry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Packing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Riding</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Teamster</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Veterinary</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Anti-Talent (Couch Potato)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>-10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Penalty</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Athletes, fitness nuts, and anyone with higher HT than you</notes>
-		</modifier>
-		<modifier version="1">
-			<name>Additional Drawback</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Penalty to recover from injuries due to physical feats</notes>
-		</modifier>
-		<reference>PU3:20</reference>
-		<categories>
-			<category>Disadvantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Acrobatics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Bicycling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Climbing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hiking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Jumping</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Lifting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Running</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Skating</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Skiing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sports</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Swimming</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Throwing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Anti-Talent (Mind like a Sieve)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>-5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Penalty</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Anybody who values knowledge</notes>
-		</modifier>
-		<modifier version="1">
-			<name>Additional Drawback</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Penalty anywhere Eidetic Memory would give a bonus</notes>
-		</modifier>
-		<reference>PU3:20</reference>
-		<categories>
-			<category>Disadvantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Area Knowledge</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Connoisseur</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Current Affairs</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hobby Skill</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Anti-Talent (Misfit)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>-15</points_per_level>
-		<modifier version="1">
-			<name>Reaction Penalty</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Anyone you try to impress</notes>
-		</modifier>
-		<modifier version="1">
-			<name>Additional Drawback</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Penalty to resist Influence skills and manipulation</notes>
-		</modifier>
-		<reference>PU3:20</reference>
-		<categories>
-			<category>Disadvantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Acting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Administration</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Carousing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Connoisseur</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Detect Lies</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Diplomacy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fast-Talk</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Gambling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Gesture</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Intimidation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Leadership</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Merchant</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Politics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Propaganda</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Public Speaking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Savoir-Faire</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sex Appeal</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Teaching</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Anti-Talent (Noncombatant)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>-15</points_per_level>
-		<modifier version="1">
-			<name>Reaction Penalty</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Anyone who would react poorly to Cowardice</notes>
-		</modifier>
-		<reference>PU3:21</reference>
-		<notes>Penalty to all combat rolls except active defenses, which are based on reduced skills instead</notes>
-		<categories>
-			<category>Disadvantage</category>
-			<category>Talent</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Anti-Talent (Unsubtle)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>-5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Penalty</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Sneaky people and anyone who catches you in the act</notes>
-		</modifier>
-		<modifier version="1">
-			<name>Additional Drawback</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to others' rolls to notice or remember you</notes>
-		</modifier>
-		<reference>PU3:21</reference>
-		<categories>
-			<category>Disadvantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Camouflage</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Disguise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Holdout</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shadowing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Smuggling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Stealth</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Armor Familiarity (@Combat Skill@)</name>
-		<type>Physical</type>
-		<levels>1</levels>
-		<points_per_level>1</points_per_level>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Armorer&#8217;s Gift (@Weapon Skill@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Atheist</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:8</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Attentive</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:17</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Autotrance</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:12</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Background Knowledge (@Background@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:16</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Bad Posture</name>
-		<type>Physical, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:13</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Base</name>
-		<type>Social</type>
-		<base_points>1</base_points>
-		<reference>PU2:17</reference>
-		<notes>@Description@</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Better (@Gear@)</name>
-		<type>Social</type>
-		<base_points>1</base_points>
-		<reference>PU2:8</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="is">High-Heeled Heroine</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Biting Mastery</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Born Goon</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Bowlegged</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Broad-Minded</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:17</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Brotherhood (@Group@)</name>
-		<type>Social</type>
-		<base_points>1</base_points>
-		<reference>PU2:17</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Bulky Frame</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Burrower</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:10</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Call of the Wild</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:12</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="is">Animal Empathy</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Can Be Turned By True Faith</name>
-		<type>Supernatural</type>
-		<base_points>-1</base_points>
-		<reference>PU6:33</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Cannot Float</name>
-		<type>Physical, Exotic</type>
-		<base_points>-1</base_points>
-		<reference>PU6:12</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Can&#8217;t Read Music</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:31</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Care (@Subject@)</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Careful</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:17</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Careful planner</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:30</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Carrier (@Disease@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Carries backup weapons</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:30</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Charm (@Spell@)</name>
-		<type>Supernatural</type>
-		<base_points>1</base_points>
-		<reference>PU2:19</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Chauvinistic</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:17</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Cheaper (@Gear@; @Percentage@%)</name>
-		<type>Social</type>
-		<base_points>1</base_points>
-		<reference>PU2:8</reference>
-		<notes>@Reason@</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="is">High-Heeled Heroine</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Checkered Past</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:32</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Chi Resistance (@Chi-based Effect@)</name>
-		<type>Supernatural</type>
-		<base_points>1</base_points>
-		<reference>PU2:19</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Citizenship (@State@)</name>
-		<type>Social</type>
-		<base_points>1</base_points>
-		<modifier version="1" enabled="no">
-			<name>Home</name>
-			<cost type="points">-1</cost>
-			<affects>total</affects>
-			<notes>You get one free citizenship.</notes>
-		</modifier>
-		<reference>PU2:17</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Classic Features (@Features@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:4</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Clean freak</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:30</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Climbing Line</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:10</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Clinch (Boxing)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Clinch (Brawling)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Clinch (Karate)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Cloaked</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Clumsy Runner</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Code of Honor</name>
+		<name>Willful Ignorance</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
 		<reference>PU6:9</reference>
@@ -1268,650 +11,107 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Cold Intolerance</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:25</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Collector (@Subject@)</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:27</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>College Incompetence (@Subject@)</name>
-		<type>Supernatural</type>
-		<base_points>-1</base_points>
-		<reference>PU6:34</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Combat Hesitancy</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Combat Vaulting (@Reach 2+ Polearm Skill@)</name>
+		<name>Weapon Bond (@Specific Weapon@)</name>
 		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Compact Frame</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
+		<reference>PU2:9</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Complicated</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:32</reference>
-		<notes>@Subject@</notes>
+		<name>Weapon Adaptation (@Weapon@ to @Weapon@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:8</reference>
 		<categories>
-			<category>Quirk</category>
+			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Compulsion</name>
+		<name>Vow (@Subject@)</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
-		<reference>PU6:27</reference>
-		<notes>@Subject@</notes>
+		<reference>PU6:9</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Congenial</name>
+		<name>Villain-Worshipper</name>
 		<type>Mental, Social</type>
 		<base_points>-1</base_points>
-		<reference>PU6:17</reference>
+		<reference>PU6:15</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Controllable Disadvantage (@Disadvantage@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:12</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Controllable Disadvantage (@Disadvantage@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Convincing Nod</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<notes>Non-Verbal Fast-Talk</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Cooperative</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Cosmetic Eyeglasses</name>
-		<type>Physical, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:13</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Cotton Stomach</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Courtesy Title (@Title@)</name>
-		<type>Social</type>
-		<levels>1</levels>
-		<points_per_level>1</points_per_level>
-		<reference>PU2:18</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Covenant of Rest</name>
-		<type>Social, Supernatural</type>
-		<base_points>1</base_points>
-		<reference>PU2:19</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Credulous</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Cross-Species Surrogacy (@Species@)</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:10</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Cross-Trained (@Skill@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:16</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Crossbow Finesse</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Cutting Edge Training (@Skill@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:16</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Cyclothymic</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:17</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dabbler</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:16</reference>
-		<notes>@Up to 8 Skills@</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Daily Ritual</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:28</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Damned</name>
-		<type>Supernatural</type>
-		<base_points>-1</base_points>
-		<reference>PU6:34</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dead Giveaway</name>
-		<type>Physical, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:13</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dead Weight</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Decisive</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:17</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Deep Sleeper</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Delusion</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:17</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Delusional Competence (@Skill@)</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:17</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Desirous</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Determined</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dirty Fighting</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Disarming Smile</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<notes>Non-Verbal Diplomacy</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Disciplined</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dishonest Face</name>
-		<type>Physical, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:14</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dislike (@Subject@)</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:26</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Disorganized</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Disposable Identity</name>
+		<name>Vehicle (@Type@)</name>
 		<type>Social</type>
 		<base_points>1</base_points>
 		<reference>PU2:18</reference>
-		<notes>@Details@</notes>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Distinctive Features</name>
-		<type>Physical, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:14</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Distinctive Speech</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:16</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Distractible</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Doesn&#8217;t trust banks</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:30</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Doodad</name>
+		<name>Variable Quirk</name>
 		<type></type>
-		<levels>1</levels>
-		<points_per_level>1</points_per_level>
-		<reference>PU2:9</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dorky</name>
-		<type>Mental, Social</type>
 		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dramatic Death</name>
-		<type>Supernatural</type>
-		<base_points>1</base_points>
-		<reference>PU2:19</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dreamer</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Drunken Fighting</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dual Identity</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:33</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dual Ready (@Single Handed Weapon Skill@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dull</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dull Smell</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dull Taste</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dull Taste and Smell</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Easily Mistaken Sex</name>
-		<type>Physical, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:14</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Easily Winded</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Eavesdropper</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:28</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Efficient (@Skill@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:16</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Emeritus Professor</name>
-		<type>Social</type>
-		<levels>1</levels>
-		<points_per_level>1</points_per_level>
-		<reference>PU2:18</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Epitome (@Subject@)</name>
-		<type>Mental/Physical, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:14</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Ex-Cop</name>
-		<type>Social</type>
-		<levels>1</levels>
-		<points_per_level>1</points_per_level>
-		<reference>PU2:18</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Exotic Equipment Training (@Equipment@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:9</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Exotic Weapon Training (@Weapon@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Expensive Habit (@Subject@)</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:28</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Extended Hearing (High)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Extended Hearing (Low)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>External Mood Influence</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
+		<reference>PU6:21</reference>
 		<notes>@Subject@</notes>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Extra Drawback (@Rule@)</name>
+		<name>Unwelcome Accessory (@Subject@)</name>
+		<type>Physical, Exotic</type>
+		<base_points>-1</base_points>
+		<reference>PU6:13</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Unusual Training (@Cinematic Technique@)</name>
+		<type></type>
+		<base_points>1</base_points>
+		<reference>PU2:21</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Unusual Posture (@Task and Posture@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:17</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Unique Technique (@Technique@)</name>
+		<type></type>
+		<base_points>1</base_points>
+		<reference>PU2:21</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Uncongenial</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Unbelievable at @Ability@</name>
 		<type></type>
 		<base_points>-1</base_points>
 		<reference>PU6:21</reference>
@@ -1920,350 +120,16 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Extra Option (@Rule@)</name>
-		<type></type>
-		<base_points>1</base_points>
-		<reference>PU2:20</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Extreme Sexual Dimorphism</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:10</reference>
-		<notes>+1 to attempts to identify you, -1 to attempts to remain anonymous.</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Sex Appeal</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount>1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Eye for Distance</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>False Memory</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:17</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Fashion Disaster</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:14</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Fast Talker</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:16</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Fatigues Easily Under Loads</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Favor Owed</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:32</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Fearsome Stare</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<notes>Non-Verbal Intimidation</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Feathers</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:10</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Flirtatious</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:28</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Flourish (@Weapon Skill@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<notes>Intimidate at +4 with ready after kill/knockdown</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Focused (@Task@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Focused Fury</name>
+		<name>Unarmed Parry (@Weapon@)</name>
 		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<notes>Combine Mighty Blows and All Out Attack</notes>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Follow-Through (@Weapon Skill@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<notes>Intimidate as free action after kill/knockdown</notes>
+		<reference>PU2:8</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Forbidden Word (@Word@)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:16</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Forgetful</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:19</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Forgettable Face</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:4</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-		<prereq_list all="yes">
-			<advantage_prereq has="no">
-				<name compare="is">Unnatural Features</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-			<advantage_prereq has="no">
-				<name compare="is">Distinctive Features</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Form Mastery (@Weapon@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Former Alcoholic</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:29</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Friend</name>
-		<type>Social</type>
-		<base_points>1</base_points>
-		<reference>PU2:18</reference>
-		<notes>@Details@</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Friendly Drunk</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:29</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Fur</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:10</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Gangster Swagger</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<notes>Non-Verbal Streetwise</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Generator</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:10</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Glimpses of Clarity</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:19</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Good with @Animal@</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Good with @Social Group@</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Grip Mastery (@Weapon@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Ground Guard</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Grudge</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:32</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Hands Free (@Skill@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:16</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Hated by @Group@</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:33</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Haughty Sneer</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<notes>Non-Verbal Savoir-Faire (High Society)</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Headhunter</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Heat Intolerance</name>
+		<name>Twitchy</name>
 		<type>Physical</type>
 		<base_points>-1</base_points>
 		<reference>PU6:25</reference>
@@ -2272,70 +138,6706 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Hedonist</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:28</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>High Rejection Threshold</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>High-Frequency Hearing Loss</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:23</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>High-Heeled Heroine</name>
-		<type>Physical</type>
+		<name>Twirl (@Weapon Skill@)</name>
+		<type>Mental/Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:14</reference>
+		<reference>PU2:15</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>High-Pressure Intolerance</name>
+		<name>Trivial Secret</name>
+		<type>Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:33</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Trivial Reputation (@Description@)</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<reference>PU2:18</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Trivial Reputation</name>
+		<type>Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:33</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Trivial Destiny</name>
+		<type>Supernatural</type>
+		<base_points>-1</base_points>
+		<reference>PU6:34</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Trivial Destiny</name>
+		<type>Supernatural</type>
+		<base_points>1</base_points>
+		<reference>PU2:20</reference>
+		<notes>@Details@</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Transporter (@Vehicle Skill@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:16</reference>
+		<notes>No rolls for some vehicle tasks.</notes>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Trademark Move</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:8</reference>
+		<notes>@Description@</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Trademark</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:30</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Tone-Deaf</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:25</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Token (@Subject@)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:16</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Tiny Hands</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:25</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Timid</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:18</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Third Person</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:16</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Thin Skull</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:25</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Tests Positive for @Condition@</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:25</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Technique Mastery (@Technique@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:17</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Technique Adaptation (@Technique@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:17</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Teamwork (@Group@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:8</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Taunting</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Tattletale</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:30</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Widget-Worker)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Those who benefit directly from your skills</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Success at an appropriate covered skill lets you scround equipment for another skill and eliminates level of the penalty for improvised equipment. Shift rolls by level to avoid harm from tampering with mundane mechanisms.</notes>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Armoury</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Forced Entry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Lockpicking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Scrounging</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Traps</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="yes">
+				<name compare="is">Gnome</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Unseelie Talent)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:17</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Camouflage</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Disguise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Scrounging</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Stealth</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Survival Urban Survival</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Truth-Seeker)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Anyone who is Curious or harbors Delusions about conspiracies</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus in Contests against attempts to perpetrate a cover-up.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Detect Lies</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is">Conspiracy Theory</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is">Conspiracies</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Intelligence Analysis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Interrogation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Research</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Trivia Sponge)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Anybody who cares about trivia</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus anywhere Eidetic Memory gives a bonus</notes>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Area Knowledge</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Current Affairs</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Games</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hobby Skill</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Tough Guy)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Most police officers and detectives, bouncers, gangsters, and street thugs</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to resist Interrogation and Intimidation, and to Fright Checks resulting from encountering murder victims, bloody torture scenes, etc.</notes>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Fast-Talk</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Forced Entry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Intimidation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shadowing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Streetwise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Thanatologist)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Death-worshippers and sapient undead you don&#8217;t try to exorcize or banish</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to fright checks from undead and bodies</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Exorcism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is">Thanatology</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Occultism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Professional Skill</name>
+			<specialization compare="is">Mortician</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Religious Ritual</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Theology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Talker)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Investigators and anybody hiring you to investigate</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to resist verbal influence attempts</notes>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Detect Lies</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Diplomacy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fast-Talk</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Savoir-Faire</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Survivor)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Scouts, campers, and survivalists.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Scrounging to find simple equipment with offseting improvides equipment penalty.  Must be simple!</notes>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">First Aid</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Knot-Tying</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Naturalist</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Scrounging</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Survival</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Superior Equilibrioception)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Acrobats, skydivers, and commandos who slide down ropes.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to DX anywhere Perfect Balance would apply</notes>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Acrobatics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Aerobatics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Aquabatics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Body Sense</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Climbing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Free Fall</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Parachuting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Super-Spy)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>15</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>All members of the character&#8217;s organization below his Rank, as well as enemy agents of roughly equal Rank who are aware of his identity</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to rank for clearance and aid, but not for authority or pay.</notes>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Acting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Current Affairs</name>
+			<specialization compare="is">Politics</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Detect Lies</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Disguise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Escape</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fast-Talk</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Holdout</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Interrogation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Observation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pickpocket</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Search</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shadowing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sleight of Hand</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Stealth</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Tracking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Strong Chi)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Other martial artists, especially potential masters or students.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>+1/level on rolls to be heard (compare Penetrating Voice, p. B101), and to Intimidation attempts made after using one of the affected skills.</notes>
+		</modifier>
+		<reference>PU3:8</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Breaking Blow</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Flying Leap</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Power Blow</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pressure Points</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pressure Secrets</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Street-Smart)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Shady characters in town.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to notice inner city dangers and scams and to Tracking in built up areas.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Merchant</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Panhandling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Scrounging</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shadowing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Streetwise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Urban Survival</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="no">
+				<name compare="is">Talent (Street Smarts)</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Street Smarts)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Other street operators</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to notice inner city dangers and scams and to Tracking in built up areas.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:16</reference>
+		<notes>Familiarity with a new city for city specific skills requires 6-level months</notes>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Area Knowledge</name>
+			<specialization compare="is">@City@</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Current Affairs</name>
+			<specialization compare="is">@City@</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Law</name>
+			<specialization compare="is">@City@</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Merchant</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Panhandling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Scrounging</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shadowing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Streetwise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Urban Survival</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="no">
+				<name compare="is">Talent (Street-Smart)</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Strangler)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to Per to notice people sneaking within arms reach of you</notes>
+		</modifier>
+		<reference>PU3:15</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Brawling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Stealth</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Tracking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Wrestling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="yes">
+				<name compare="is">Throttler</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Stalker)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Hunters, trackers, etc.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>+1/level to Per rolls to keep track of a specific quarry you&#8217;ve already spotted using other skills.</notes>
+		</modifier>
+		<reference>PU3:15</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Camouflage</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hiking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Navigation (Land)</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Stealth</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Tracking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Spirit-Talker)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Spirits</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:15</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Exorcism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fortune-Telling</name>
+			<specialization compare="is anything">Augury</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fortune-Telling</name>
+			<specialization compare="is anything">Dream Interpretation</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is anything">Spirits</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Meditation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Occultism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Theology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Social Scientist)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Social and political thinkers, theorists, and activists</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to Acting, Disguise, and Fast-Talk to pass as a member of another political/religious group.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:15</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Anthropology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Archaeology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Criminology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Economics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is">Political Science</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Geography</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">History</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Philosophy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sociology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Theology</name>
+			<specialization compare="is">Comparative</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Smooth Operator)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>15</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Con artists, politicians, salesmen, etc. &#8211; but only if you aren&#8217;t trying to manipulate them.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to resist covered skills</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-2</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:15</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Acting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Carousing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Detect Lies</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Diplomacy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fast-Talk</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Intimidation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Leadership</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Panhandling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Politics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Public Speaking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Savoir-Faire</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sex Appeal</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Streetwise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Seafarer)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Sailors, pirates, and aquatic races sympathetic to sea travel</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to resist seasicknes and reduce unfamiliarity penalties for system on an appropriate boat or ship. Bonus to Carousing and Streetwise in port towns.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:14</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Boating</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fishing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Knot-Tying</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Meteorology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Weather Sense</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Navigation</name>
+			<specialization compare="is anything">Sea</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Seamanship</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Survival</name>
+			<specialization compare="is anything">Island/Beach</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Swimming</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Thrown Weapon</name>
+			<specialization compare="is anything">Harpoon</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="no">
+				<name compare="is">Talent (Born Sailor)</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+			<advantage_prereq has="no">
+				<name compare="is">Talent (Mariner)</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Sage)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Scholars, students, and people who consult you</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to IQ defaults to non-covered skills for general knowledge only</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">2</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:15</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Archaeology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Geography</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Heraldry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">History</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Law</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Literature</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Occultism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Philosophy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Research</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Theology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Psientist)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Psis</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to self control rolls after a successful Meditation, Mental Strength, or Mind Block</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:15</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Hypnotism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Meditation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mental Strength</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mind Block</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is">Psionics</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is">Psionics</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Pop Culture Maven)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Obsessive pop culture devotees</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to Influence or Carousing to demonstrate you are "cool".</notes>
+		</modifier>
+		<reference>PU3:14</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Connoisseur</name>
+			<specialization compare="is anything">Virtual Reality Arts</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Current Affairs</name>
+			<specialization compare="is anything">People</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Current Affairs</name>
+			<specialization compare="is anything">Popular Culture</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Current Affairs</name>
+			<specialization compare="is anything">Sports</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is anything">Memetics</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Poet)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Readers and listeners of your work; literati.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>+1/level to the first Influence roll (p. B359) of any kind made on an audience member (or several of them as a group) after a successful performance.</notes>
+		</modifier>
+		<reference>PU3:14</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Connoisseur (Literature)</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Literature</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Poetry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Public Speaking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Writing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Pickaxe Penchant)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Miners</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to will for Extra Effort when digging, HT on failure at such, and all rolls to avoid disasters in mines</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">0</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:14</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Axe/Mace</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Forced Entry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Prospecting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Thrown Weapon</name>
+			<specialization compare="is anything">Axe/Mace</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Two-Handed Axe/Mace</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="yes">
+				<name compare="is">Dwarf</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Parapsychologist)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Psis and beleivers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to resist powers that have been examined with covered skills</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:14</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Electronics Operation</name>
+			<specialization compare="is anything">Medical</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Electronics Operation</name>
+			<specialization compare="is anything">Psychotronics</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Electronics Operation</name>
+			<specialization compare="is anything">Scientific</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is anything">Psionics</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hypnotism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Occultism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Physics</name>
+			<specialization compare="is anything">Paraphysics</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Outdoorsman)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Explorers and nature lovers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to HT rolls to avoid harm from failure of covered skills</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-3</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:14</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Camouflage</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fishing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mimicry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Naturalist</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Navigation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Survival</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Tracking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Occultist)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Students of the arcane, gullible college students, monster-hunters.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Benefit</name>
+			<cost type="points">2</cost>
+			<affects>levels only</affects>
+			<notes>+1/level to Fright Checks caused by supernatural beings and effects, and by reading sanity-destroying tomes (because you know what to expect).</notes>
+		</modifier>
+		<reference>PU3:14</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Alchemy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Anthropology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Archaeology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Exorcism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">History</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Linguistics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Literature</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Occultism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Research</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Ritual Magic</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Thaumatology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Ninja Talent)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1" enabled="no">
+			<name>Power Talent</name>
+			<reference>DF12:4</reference>
+			<cost type="points">5</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:7</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Blind Fighting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hypnotism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Invisibility Art</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Light Walk</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mental Strength</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Natural Scientist)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Scientists and those impressed by "smart people"</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Reduce TL and familiarity penalties for gear examined for an hour with a covered skill</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:13</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Astronomy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Chemistry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is anything">Hydrology</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is anything">Natural Philosophy</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Geology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mathematics</name>
+			<specialization compare="is anything">Applied</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mathematics</name>
+			<specialization compare="is anything">Statistics</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mathematics</name>
+			<specialization compare="is anything">Surveying</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Metallurgy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Meteorology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Paleontology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Physics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pysiology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Natural Diver)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Expert divers and aquatic beings</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to HT for breath holding time and resisting the Bends, Nitrogen Narcosis, etc.</notes>
+		</modifier>
+		<reference>PU3:13</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Aquabatics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Diving Suit</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Scuba</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is anything">Submarine</name>
+			<specialization compare="is">Free-Flooding Sub</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Swimming</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Natural Copper)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Police and PIs</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to unskilled Per rolls to notice clues, and to all rolls to use Intuition</notes>
+		</modifier>
+		<reference>PU3:13</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Body Language</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Criminology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Detect Lies</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Intelligence Analysis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Interrogation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Observation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Savoir-Faire</name>
+			<specialization compare="is anything">Police</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Search</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shadowing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Streetwise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Natural Athlete)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Sports fans, coaches, and recruiters</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to HT to recover from injuries resulting from failures with covered skills</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:13</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Bicycling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Breath Control</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hiking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Jumping</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Lifting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Running</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Skating</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Skiing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sports</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Swimming</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Throwing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Musical Ability)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Audiences and Critics</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to first influence roll made against one or more audience members after a successful performance.</notes>
+		</modifier>
+		<reference>PU3:13</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Group Performance</name>
+			<specialization compare="is">Conducting</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Musical Composition</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Musical Influence</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Musical Instrument</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Singing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Mr. Smash)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to intimidate when victim at your mercy and you are threatening with a covered weapon</notes>
+		</modifier>
+		<reference>PU3:13</reference>
+		<notes>Covers Forced-Entry, but only when used with a swung Two Handed weapon.</notes>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Polearm</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Two-Handed Axe/Mace</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Two-Handed Flail</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Two-Handed Sword</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Mesmerist)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>The foolish and weak-minded.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>+1/level to resist any of the affected skills.</notes>
+		</modifier>
+		<reference>PU3:12</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Autohypnosis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Brainwashing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Captivate</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Gesture</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hypnotism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Intimidation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Musical Influence</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Persuade</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Suggest</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sway Emotions</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Memetics)</name>
+		<type>Mental, Exotic</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Other memeticists who see you working</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to resist Brainwashing, Fast-Talk, and Propaganda</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">2</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:12</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Brainwashing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Diplomacy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is anything">Memetics</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fast-Talk</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Interrogation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Leadership</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Merchant</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Politics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Propaganda</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sociology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Teaching</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Mathematical Ability)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Engineers and scientists</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to resist deception involving numbers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-2</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:12</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Accounting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Astronomy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Cryptography</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Engineer</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Finance</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Market Analysis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mathematics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Physics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Master Builder)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Workers on projects, prospective employers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to avoid common workplace hazards, even if used as traps</notes>
+		</modifier>
+		<reference>PU3:11</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Architecture</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Carpentry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Engineer</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Forced Entry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Masonry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Mariner)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Seafarers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to resist seasicknes and reduce unfamiliarity penalties for system on an appropriate boat or ship</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-3</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:13</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Boating</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Freight Handling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Knot-Tying</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Meteorology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Navigation</name>
+			<specialization compare="is">Sea</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Seamanship</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shiphandling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Weather Sense</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="no">
+				<name compare="is">Talent (Born Sailor)</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Jack of All Trades)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<reference>PU3:11</reference>
+		<notes>Bonus to all defaults from attributes</notes>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Intuitive Statesman)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Political Parties seeking candidates, those who put you in power</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to influence rolls to be chosen over another for a job or posting, or to cover up a failure with a covered skill.</notes>
+		</modifier>
+		<reference>PU3:11</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Administration</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Current Affairs</name>
+			<specialization compare="is">Headline News</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Current Affairs</name>
+			<specialization compare="is">People</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Current Affairs</name>
+			<specialization compare="is">Politics</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Diplomacy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Economics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Law</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Leadership</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Politics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Propaganda</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Public Speaking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Intuitive Admiral (Space))</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Anyone you serve with or command</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to initiative roll if leader</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-2</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:12</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is">Military Science</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">History</name>
+			<specialization compare="ends with">Military</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Intelligence Analysis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Leadership</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Savoir-Faire</name>
+			<specialization compare="is">Military</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shiphandling</name>
+			<specialization compare="is">Spaceship</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shiphandling</name>
+			<specialization compare="is">Starship</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Spacer</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Strategy</name>
+			<specialization compare="is">Space</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Intuitive Admiral (Sea))</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Anyone you serve with or command</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to initiative roll if leader</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-2</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:12</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is">Military Science</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">History</name>
+			<specialization compare="ends with">Military</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Intelligence Analysis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Leadership</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Savoir-Faire</name>
+			<specialization compare="is">Military</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shiphandling</name>
+			<specialization compare="is">Ship</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shiphandling</name>
+			<specialization compare="is">Submarine</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Seamanship</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Strategy</name>
+			<specialization compare="is">Sea</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Submariner</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Inner Balance)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>15</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Pacifists, Ascetics, Soft stylists</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to resist mundane disease</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:7</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Autohypnosis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Blind Fighting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Body Control</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Body Language</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Body Sense</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Breath Control</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Dreaming</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Immovable Stance</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Light Walk</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Lizard Climb</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Meditation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mental Strength</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mind Block</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sensitivity</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Impersonator)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus in contests against covered skills</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:11</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Acting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Body Language</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Disguise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mimicry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Savoir-Faire</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Streetwise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Hot Pilot)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Other Pilots</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Reduce penalties for unfamiliar systems of vehicles you have Piloting skill for</notes>
+		</modifier>
+		<reference>PU3:11</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Gunner</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Navigation</name>
+			<specialization compare="is">Air</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Navigation</name>
+			<specialization compare="is">Space</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Piloting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Healer)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Patients</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to HT rolls for a specific patient and condition if treated full time.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:11</reference>
+		<notes>Modern</notes>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Diagnosis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Esoteric Medicine</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">First Aid</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pharmacy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Physician</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Physiology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Surgery</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Veterinary</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Electronics Operation</name>
+			<specialization compare="is">Medical</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is">Epidemiology</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="no">
+				<name compare="is">Talent (Healer)</name>
+				<notes compare="does not contain">Modern</notes>
+				<level compare="at least">1</level>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Healer)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Patients</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to HT rolls for a specific patient and condition if treated full time.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:11</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Diagnosis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Esoteric Medicine</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">First Aid</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pharmacy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Physician</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Physiology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Surgery</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Veterinary</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="no">
+				<name compare="is">Talent (Healer)</name>
+				<notes compare="contains">Modern</notes>
+				<level compare="at least">1</level>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Green Thumb)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Gardeners and Sentient plants</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to rolls to survive made by plants in your care.</notes>
+		</modifier>
+		<reference>PU3:11</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Biology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Farming</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Gardening</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Herb Lore</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Naturalist</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Goodwife)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Beneficiaries, prospective spouses, other housewives</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to defaults made in your own home to repair, maintain, and protect it.</notes>
+		</modifier>
+		<reference>PU3:10</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Cooking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Diagnosis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Gardening</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Housekeeping</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sewing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Gifted Artist)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Buyers and Critics</notes>
+		</modifier>
+		<reference>PU3:10</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Artist</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Jeweler</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Leatherworking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Photography</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sewing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Forest Guardian)</name>
+		<type>Mental, Exotic, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Druids, Faeries, and bunnies</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to notice intruders, etc in woodland where you've lived from 6-level months.</notes>
+		</modifier>
+		<reference>PU3:10</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Bow</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Camouflage</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fast-Draw</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Stealth</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Survival</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="yes">
+				<name compare="ends with">Elf</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Forensics Whiz Kid)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Crime-lab employers and detectives</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to Per to spot clues when no skill applies</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Chemistry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Criminology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Diagnosis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Forensics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Research</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Forceful Chi)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>15</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Honourable opponents, Hard stylists, Lovers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to be heard or to Intimidation after using a covered skill</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:7</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Breaking Blow</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Erotic Art</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Flying Leap</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hypnotic Hands</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hypnotism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Invisibility Art</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Kiai</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Power Blow</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Precognitive Parry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pressure Points</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pressure Secrets</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Push</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Throwing Art</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Zen Archery</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Explorer)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Fellow explorers and backers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Reduce distance and area class penalties for all skills</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">0</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:10</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Area Knowledge</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Cartography</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Geography</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mathematics</name>
+			<specialization compare="is">Surveying</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Navigation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Empath)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>IQ-4+level roll as for Empathy</notes>
+		</modifier>
+		<reference>PU3:10</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Body Language</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Detect Lies</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Diplomacy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fortune-Telling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Elder Gift)</name>
+		<type>Mental, Exotic, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Elder Things</notes>
+		</modifier>
+		<reference>PU3:6</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Alchemy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Occultism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Thaumatology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Dungeon Artificer)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Potential Buyers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Roll appropriate skill to scrounge equipment for other covered skills and apply level against the penalty.  Shift rolls to avoid ill effects from mysterious artifacts by level in either direction.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:10</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Alchemy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Armoury</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Engineer</name>
+			<specialization compare="is">Gadgets</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fast-Draw</name>
+			<specialization compare="is">Gadgets</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Scrounging</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Traps</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Driver's Reflexes)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Passengers; gamblers betting on you at the Grand Prix.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>+1/level on Per rolls to notice dangers in the path of your ride: running children, oncoming vehicles, landmines...</notes>
+		</modifier>
+		<reference>PU3:10</reference>
+		<categories>
+			<category>Advantage</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Boating</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Driving</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Piloting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Submarine</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Devotion)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Coreligionists and sympathizers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to will to resist "evil influences"</notes>
+		</modifier>
+		<reference>PU3:9</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Autohypnosis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Exorcism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Meditation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Religious Ritual</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Cyberneticist)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Other computer professionals, AI systems, and robots</notes>
+		</modifier>
+		<reference>PU3:9</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Computer Hacking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Computer Operation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Computer Programming</name>
+			<specialization compare="is"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Computer Programming</name>
+			<specialization compare="is">AI</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Electronics Repair</name>
+			<specialization compare="is">Computers</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Cunning Folk)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Local peasantry, clients, and acolytes.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Benefit</name>
+			<cost type="points">-2</cost>
+			<affects>levels only</affects>
+			<notes>A roll at IQ-4, +1/level of Cunning Folk, to notice anything odd &#8211; curses, blights, faeries in the basement, etc. &#8211; that happens to animals, crops, or people in an area where you&#8217;ve lived for at least (6 - Cunning Folk level) months.</notes>
+		</modifier>
+		<reference>PU3:9</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Animal Handling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fortune-Telling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Herb Lore</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Naturalist</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Occultism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Poisons</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Veterinary</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Weather Sense</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Cultural Chameleon)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Other cultures in their lands</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:9</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Anthropology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Diplomacy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Gesture</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Linguistics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sociology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Craftiness)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus: None</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:9</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Camouflage</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Disguise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Holdout</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shadowing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Stealth</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Acting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Computer Wizard)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Computer professionals and AIs</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Reduce Familiarity penalties for computers. Roll Hacking/Programming to improvise software to reduce equipment penalty.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:9</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Computer Operation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Computer Programming</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Electronics Operation</name>
+			<specialization compare="is">Communications</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Electronics Operation</name>
+			<specialization compare="is">Media</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Electronics Repair</name>
+			<specialization compare="is">Computers</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is">Computer Security</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is">AI</specialization>
+			<category compare="is anything"></category>
+			<amount>1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Clown)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Audiences, circus performers, vaudevillians, and fellow fools</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>+1/level to first influence roll made against one or more audience members after a successful performance.</notes>
+		</modifier>
+		<reference>PU3:8</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Acrobatics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Dancing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fire Eating</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hobby Skill</name>
+			<specialization compare="is">Juggling</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Makeup</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mimicry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Performance</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Singing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sleight of Hand</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Ventriloquism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Close to the Earth)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Those who respect nature</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>IQ-4+Level to notice disturbances in nature</notes>
+		</modifier>
+		<reference>PU3:8</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is">Elementals</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Naturalist</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Religious Ritual</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Theology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Weather Sense</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is">Faeries</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is">Nature Spirits</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Close to Hell)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Demons</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:8</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Exorcism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is">Demons</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Occultism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is">Demons</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Religious Ritual</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Theology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Close to Heaven)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Any fellow &#8220;religious professional&#8221;</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>IQ-4+Level to notice omens and blessed items</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:8</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Meditation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Religious Ritual</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Theology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Ritual Magic</name>
+			<specialization compare="is">@Religion@</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Symbol Drawing</name>
+			<specialization compare="is">@Religion@</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Exorcism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Circuit Sense)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Anyone for whom you use your skills</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>-1/level less-severe penalties from Familiarity (p. B169) &#8211; which can run to -10 in certain cases (see p. B189) &#8211; when using any skill to operate unfamiliar gear that runs on electricity.</notes>
+		</modifier>
+		<reference>PU3:8</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Electrician</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Electronics Operation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Electronics Repair</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Engineer (Electrical and Electronics)</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Chi Talent)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>15</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus: None</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+		</modifier>
+		<reference>PU3:7</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Autohypnosis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Blind Fighting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Body Control</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Breaking Blow</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Breath Control</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Esoteric Medicine</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Flying Leap</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Immovable Stance</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Invisibility Art</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Kiai</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Light Walk</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mental Strength</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mind Block</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Parry Missile Weapons</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Power Blow</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pressure Points</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pressure Secrets</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Push</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Throwing Art</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Zen Archery</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Chi Talent)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>15</points_per_level>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">5</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:7</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Autohypnosis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Blind Fighting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Body Control</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Breaking Blow</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Breath Control</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Esoteric Medicine</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Flying Leap</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Immovable Stance</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Invisibility Art</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Kiai</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Light Walk</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mental Strength</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mind Block</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Parry Missile Weapons</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Power Blow</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pressure Points</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pressure Secrets</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Push</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Throwing Art</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Zen Archery</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Business Acumen)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus: Anyone with whom you do business.</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-2</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:7</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Accounting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Administration</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Economics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Finance</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Gambling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Market Analysis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Merchant</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Propaganda</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Born War Leader)</name>
+		<type>Physical</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<reference>DF1:14,PU3:12</reference>
+		<categories>
+			<category>Advantage</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">leadership</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">strategy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="starts with">tactics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">intelligence analysis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">savoir-faire</name>
+			<specialization compare="is">military</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Born to Be Wired)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Hackers; people buying stock in your dot-com.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>-1/level less-severe penalties from Familiarity (p. B169) for unfamiliar computer equipment, and/or success at Computer Hacking or Computer Programming lets you improvise code that removes -1/level from the penalty for not having proper software for a task that requires it (p. B345).</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:8</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Computer Hacking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Computer Operation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Computer Programming</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Cryptography</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Electronics Repair (Computers)</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill (Computer Security)</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Born Tactician)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Anyone you serve with or command</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to initiative rolls if leader</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-2</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:12</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">History</name>
+			<specialization compare="contains">Military</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Intelligence Analysis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Leadership</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Savoir-Faire</name>
+			<specialization compare="is">Military</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Soldier</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Strategy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Tactics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is anything">Military Science</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Born Spacer)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Professional Spacers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>+1/Level to ST for zero G push off.  Reduce penalty for unfamiliar spacecraft.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:7</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Aerobatics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Free Fall</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Navigation</name>
+			<specialization compare="is">Space</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Piloting</name>
+			<specialization compare="is">High-Performance Spacecraft</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Piloting</name>
+			<specialization compare="is">Low-Performance Spacecraft</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Piloting</name>
+			<specialization compare="is">Aerospace</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Spacer</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Vacc Suit</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Born Soldier)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Those you serve with or command</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Reduce chance of impersonal battlefield hazards</notes>
+		</modifier>
+		<reference>PU3:12</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Leadership</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Savoir-Faire</name>
+			<specialization compare="is anything">Military</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Scrounging</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Soldier</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Tactics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Born Sailor)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Sailors</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to resist seasickness and reduce unfamiliarity penalties for system on an appropriate boat or ship</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:13</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Boating</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Knot-Tying</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Meteorology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Navigation</name>
+			<specialization compare="is">Sea</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Seamanship</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shiphandling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Weather Sense</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="no">
+				<name compare="is">Talent (Mariner)</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Born Entertainer)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Crowds</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>+1/level to first influence roll made against one or more audience members after a successful performance.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:6</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">acting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">dancing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">performance</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">public speaking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">singing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">stage combat</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Beastmaster)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Animals</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">2</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:6</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">animal handling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">disguise</name>
+			<specialization compare="is anything">animals</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">falconry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">flight</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">hidden lore</name>
+			<specialization compare="is">lycanthropes</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">mimicry</name>
+			<specialization compare="is">animal sounds</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">mimicry</name>
+			<specialization compare="is">bird calls</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">mount</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">naturalist</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">packing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">riding</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">teamster</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">veterinary</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount>1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Bard)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Audiences and fellow bards</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to first influence roll made against one or more audience members after a successful performance.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:6</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">heraldry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">literature</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">musical influence</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">poetry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">public speaking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">singing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Artificer)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Employers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Eliminate -1/level to a skill with success on another to improvise tools; Apply to Enigmatic Device Table rolls and other unskilled tech rolls.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:6</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">armoury</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">carpentry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">electrician</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">electronics repair</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">engineer</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">machinist</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">masonry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">mechanic</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">smith</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Antiquary)</name>
+		<type>Physical</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus: Devotees of the old and beautiful.</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Benefit</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:6</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Architecture</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Connoisseur</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Heraldry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">History</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Literature</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Research</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Animal Friend)</name>
+		<type>Physical</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<reference>PU3:6</reference>
+		<notes>Reaction Bonus: All ordinary animals</notes>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Animal Handling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Falconry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Packing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Riding</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Teamster</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Veterinary</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Allure)</name>
+		<type>Physical</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<reference>PU3:6</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Dancing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Erotic Art</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Makeup</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sex Appeal</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Singing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Alien Friend)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Aliens</notes>
+		</modifier>
+		<reference>PU3:6</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Diplomacy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is">Xenology</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Anthropology</name>
+			<specialization compare="is">@Alien@</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">History</name>
+			<specialization compare="is">@Alien@</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is">@Alien@</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Academic)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Students and teachers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>+1/Level to any roll that benefits from Eidetic Memory</notes>
+		</modifier>
+		<reference>PU3:6</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Public Speaking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Research</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Speed-Reading</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Teaching</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Writing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Taboo Traits (@Subject@)</name>
+		<type></type>
+		<base_points>-1</base_points>
+		<reference>PU6:21</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Symbol-Shy</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:31</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Swinging</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:16</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Suspicious</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Susceptible to @Item@</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:24</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sure-Footed (Water)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:8</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sure-Footed (Uneven)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:8</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sure-Footed (Snow)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:8</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sure-Footed (Slippery)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:8</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sure-Footed (Sand)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:8</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sure-Footed (Ice)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:8</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sure-Footed (@Surface@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:8</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Supersuit</name>
+		<type>Physical, Supernatural</type>
+		<base_points>1</base_points>
+		<reference>PU2:9</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Superstition</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:9</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Supernatural Features</name>
+		<type>Supernatural</type>
+		<base_points>-1</base_points>
+		<reference>PU6:34</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Supernatural Dislike</name>
+		<type>Supernatural</type>
+		<base_points>-1</base_points>
+		<reference>PU6:34</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sunburns Easily</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:24</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Suit Familiarity (@Environment Suit skill@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:9</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Successful at @Ability@</name>
+		<type></type>
+		<base_points>-1</base_points>
+		<reference>PU6:21</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Substance Intolerance (@Subject@)</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:25</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Style Familiarity (@Style@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Strongbow</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Striking Surface</name>
 		<type>Physical, Exotic</type>
-		<base_points>-1</base_points>
-		<reference>PU6:12</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Hoarder</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:28</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Honest Face</name>
-		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:4</reference>
+		<reference>PU2:12</reference>
+		<notes>Requires DR 3+ without Flexible, Force Field, or Tough Skin.</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+		<prereq_list all="yes">
+			<advantage_prereq has="yes">
+				<name compare="is">Damage Resistance</name>
+				<notes compare="is anything"></notes>
+				<level compare="at least">3</level>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Stereotype (@Subject@)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:16</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Standard Operating Procedure (On Alert)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Horrible Hangovers</name>
+		<name>Standard Operating Procedure (Off-Screen Reload)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Standard Operating Procedure (Last Man Out)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Standard Operating Procedure (Full Tank)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Standard Operating Procedure (Energizer)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Standard Operating Procedure (Back to the Wall)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Staid</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Spirit Contract (@Patron@)</name>
+		<type>Social, Supernatural</type>
+		<base_points>1</base_points>
+		<reference>PU2:20</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Spell Susceptibility (@Spell@)</name>
+		<type>Supernatural</type>
+		<base_points>-1</base_points>
+		<reference>PU6:34</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Spell Signature</name>
+		<type>Supernatural</type>
+		<base_points>-1</base_points>
+		<reference>PU6:34</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Special Setup (@New setup &gt; Technique@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Special Exercises (@Attribute, Characteristics or Advantage@)</name>
+		<type></type>
+		<levels>1</levels>
+		<points_per_level>1</points_per_level>
+		<reference>PU2:21</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Soft Spot (@Group@)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:27</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Slow Reflexes</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:24</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Slightly Unusual Biochemistry</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:24</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sleepyhead</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:24</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sleepy Drinker</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
 		<reference>PU6:29</reference>
@@ -2344,36 +6846,115 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Huge Weapons (SM)</name>
-		<type>Physical, Exotic</type>
-		<levels>1</levels>
-		<points_per_level>1</points_per_level>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Huge Weapons (ST)</name>
-		<type>Physical, Exotic</type>
-		<levels>1</levels>
-		<points_per_level>1</points_per_level>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Humble</name>
-		<type>Mental, Social</type>
+		<name>Sleeptalker</name>
+		<type>Physical</type>
 		<base_points>-1</base_points>
-		<reference>PU6:19</reference>
+		<reference>PU6:24</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Hungry</name>
+		<name>Sleep of the Dead</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:24</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Skintight</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Skill Adaptation (@Specific skill use@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:17</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Show-Off (@Skill@)</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:32</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+		<prereq_list all="yes">
+			<skill_prereq has="yes">
+				<name compare="is">@Skill@</name>
+				<specialization compare="is anything"></specialization>
+				<level compare="at least">1</level>
+			</skill_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Shoves and Tackles (@Long Weapon@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Shocking Affectation</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Shield-Wall Training</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sharpens weapons at every opportunity</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:30</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Shaky Hands</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:24</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sexy Pose</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<notes>Non-Verbal Sex Appeal</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sexless</name>
 		<type>Physical</type>
 		<base_points>-1</base_points>
 		<reference>PU6:23</reference>
@@ -2382,17 +6963,1229 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Hyper-Specialization (@Skill@; @Specialty@)</name>
-		<type>Mental/Physical</type>
+		<name>Serious</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Self-Imposed Limit</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:27</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Secretive</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Secret Styles (@Move Name@)</name>
+		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:16</reference>
-		<notes>+5 to specialty</notes>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Secret Powers</name>
+		<type>Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:33</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Secret Knowledge (@Skill@)</name>
+		<type></type>
+		<base_points>1</base_points>
+		<reference>PU2:20</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Idealistic</name>
+		<name>Sea Legs</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Scales</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:12</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sartorial Integrity</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sanitized Metabolism</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:12</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sacrificial Parry (@Weapon@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Rules Exemption (@Rule@)</name>
+		<type></type>
+		<base_points>1</base_points>
+		<reference>PU2:20</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Rules Exclusion (@Rule@)</name>
+		<type></type>
+		<base_points>-1</base_points>
+		<reference>PU6:21</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Rule of 17 (@Skill@)</name>
+		<type>Supernatural</type>
+		<base_points>1</base_points>
+		<reference>PU2:20</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Rule of 15 (@Class of skills@)</name>
+		<type>Supernatural</type>
+		<base_points>-1</base_points>
+		<reference>PU6:34</reference>
+		<notes>Requires at least one applicable skill at 16+.</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Rule of 15</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Robust (@Sense@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Risk-Taking Behavior</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:30</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Rinse</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:12</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Restricted Casting Style</name>
+		<type>Supernatural</type>
+		<base_points>-1</base_points>
+		<reference>PU6:34</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Restless Sleeper</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:24</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Rest in Pieces</name>
+		<type>Supernatural</type>
+		<base_points>1</base_points>
+		<reference>PU2:19</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Responsive</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Responsible</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Resistant to @Specific Poison@</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<notes>+3 to resist</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Residual Personality</name>
+		<type>Supernatural</type>
+		<base_points>-1</base_points>
+		<reference>PU6:34</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Reproductive Control (Reabsorption)</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:12</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Reproductive Control (Fertility Control)</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:12</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Religious Belief (@Subject@)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:8</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Red Tape</name>
+		<type>Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:33</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Record-Keeper</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:29</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Reach Mastery (@Weapon@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<notes>Let you change reach as a free action</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Razor Kicks</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Rapid Retraction (Punches)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Rapid Retraction (Kicks)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Rapid Retraction (Bites)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Quick-Swap (@Weapon@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Quick-Sheathe (@Weapon@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Purpose (@Purpose@)</name>
+		<type>Supernatural</type>
+		<base_points>1</base_points>
+		<reference>PU2:19</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Proud</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Pretense</name>
+		<type>Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:33</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Pressure-Tolerant Lungs</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:11</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Preferred Tactics</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:26</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Preferred Looks</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:26</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Practical Joker</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:30</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Power Grappling</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Positive Secret</name>
+		<type>Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:33</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Posh</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:18</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Poor Night Vision</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:24</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Pistol-Fist (@Pistol Skill@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Photosensitivity</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:24</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Photogenic</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:4</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Philosophical Belief (@Subject@)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:8</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Pet (@Type@)</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<reference>PU2:18</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Personality Change</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Permit (@Type@)</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<reference>PU2:18</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Periscope</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:11</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Perfume</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:11</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Perfectionist</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Penetrating Voice</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Peg-Leg Fighting</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+		<prereq_list all="yes">
+			<advantage_prereq has="yes">
+				<name compare="starts with">Lame</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Patience of Job</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Passing Appearance (Passing Complexion)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:4</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Passing Appearance (Androgynous)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:4</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Passing Appearance (@Group@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:4</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Parthenogenesis</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:11</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Pants-Positive Safety</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Pain-Sensitive</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:23</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Overweight</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:23</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Overspecialization (@Skill@)</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:31</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+		<prereq_list all="yes">
+			<skill_prereq has="yes">
+				<name compare="is">@Skill@</name>
+				<specialization compare="is anything"></specialization>
+				<level compare="at least">1</level>
+			</skill_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Overcautious Habit</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:30</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>One-Way Literacy (@Language@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>One-Way Fluency (@Language@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>One-Task Wonder (@Task@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:17</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>One-Armed Bandit (@Guns Skill@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Office (@Type@)</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<reference>PU2:18</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Off-Hand Training (@Skill@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:16</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Odious Personal Habit</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Obvious</name>
+		<type>Physical, Exotic</type>
+		<base_points>-1</base_points>
+		<reference>PU6:12</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Obsession (@Subject@)</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:29</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Obscure True Name</name>
+		<type>Social, Supernatural</type>
+		<base_points>1</base_points>
+		<reference>PU2:19</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Nosy</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Nostalgic</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:19</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>No Visible Damage</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:11</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+		<prereq_list all="yes">
+			<advantage_prereq has="yes">
+				<name compare="is">Unkillable</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>No Nuisance Rolls (@Task@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:16</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>No Hangover</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>No Degeneration in Zero-G</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:11</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Never raises voice</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:30</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Neutered</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:23</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Nervous Stomach</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:25</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Neck Control (@Unarmed Striking Skill@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Naval Training</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Natural Pockets</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<notes>@Details@</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Nano-Fever</name>
+		<type>Physical, Exotic</type>
+		<base_points>-1</base_points>
+		<reference>PU6:12</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Named Possession (@Name@)</name>
+		<type>Social, Supernatural</type>
+		<base_points>1</base_points>
+		<reference>PU2:19</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Name-Bound</name>
+		<type>Supernatural</type>
+		<base_points>-1</base_points>
+		<reference>PU6:34</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Missing Toes</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:23</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Missing Teeth</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:23</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Minor Handicap (@Subject@)</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:23</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Minor Alcoholism</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:29</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Minor Addiction (@Subject@)</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:29</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Mind-Numbing Magnetism</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Mild Dyslexia</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:31</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Methodical</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:19</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Math-Shy</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:31</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Masked</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Magic School Familiarity (@School@)</name>
+		<type>Mental, Social, Supernatural</type>
+		<base_points>1</base_points>
+		<reference>PU2:19</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Low-Pressure Intolerance</name>
+		<type>Physical, Exotic</type>
+		<base_points>-1</base_points>
+		<reference>PU6:12</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Low-Frequency Hearing Loss</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:23</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Low Rejection Threshold</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Loud Voice</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:16</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Looks Good in Uniform</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Long Fingers</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:11</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Literal-Minded</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:19</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Limited Colorblindness</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:23</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Limited Camouflage (@Environment@)</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:11</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Like (@Subject@)</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:26</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>License (@Type@)</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<reference>PU2:18</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Legalistic</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:9</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Lazy Skill (@Attribute@-based @Skill@)</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:31</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+		<prereq_list all="yes">
+			<skill_prereq has="yes">
+				<name compare="is">@Skill@</name>
+				<specialization compare="is anything"></specialization>
+			</skill_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Layabout</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:19</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Job Hunter</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Iron Body Parts (Iron Neck)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Iron Body Parts (Iron Legs)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Iron Body Parts (Iron Hands)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Iron Body Parts (Iron Arms)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Involuntary Utterance</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:16</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Intuitive Repairman (@Item@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:9</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Intolerance (@Small Group@)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:26</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Interviews Badly</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Insensitive</name>
 		<type>Mental, Social</type>
 		<base_points>-1</base_points>
 		<reference>PU6:19</reference>
@@ -2401,34 +8194,103 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Ignition</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:10</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Ill-Advised Hobby (@Subject@)</name>
+		<name>Incompetence (@Skill@)</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
-		<reference>PU6:28</reference>
+		<reference>PU6:31</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+		<prereq_list all="yes">
+			<skill_prereq has="no">
+				<name compare="is">@Skill@</name>
+				<specialization compare="is anything"></specialization>
+			</skill_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Inappropriate Manner (Wishy-Washy)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Illumination</name>
-		<type>Physical, Exotic</type>
+		<name>Inappropriate Manner (Scummy)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Inappropriate Manner (Salacious)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Inappropriate Manner (Pushy)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Inappropriate Manner (Oily)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Inappropriate Manner (Aristocratic)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Inappropriate Manner (@Subject@)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:14</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Inaccessible Idioms</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:16</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Improvised Weapons (@Combat Skill@)</name>
+		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:10</reference>
+		<reference>PU2:6</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Imaginative</name>
+		<name>Impatient</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
 		<reference>PU6:19</reference>
@@ -2437,98 +8299,21 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Imbue</name>
-		<type>Mental, Supernatural</type>
-		<modifier version="1" enabled="no">
-			<name>Imbue level 1</name>
-			<cost type="points">10</cost>
-			<affects>total</affects>
-			<reference>PU1:4</reference>
-			<notes>Novice imbuement skills available.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Imbue level 2</name>
-			<cost type="points">20</cost>
-			<affects>total</affects>
-			<reference>PU1:4</reference>
-			<notes>Intermediate (and easier) imbuement skills available.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Imbue level 3</name>
-			<cost type="points">40</cost>
-			<affects>total</affects>
-			<reference>PU1:4</reference>
-			<notes>Master (and easier) imbuement skills available.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Chi</name>
-			<cost type="percentage">-10</cost>
-			<affects>total</affects>
-			<reference>PU1:4</reference>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Divine</name>
-			<cost type="percentage">-10</cost>
-			<affects>total</affects>
-			<reference>PU1:4</reference>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Magical</name>
-			<cost type="percentage">-10</cost>
-			<affects>total</affects>
-			<reference>PU1:4</reference>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Psionic</name>
-			<cost type="percentage">-10</cost>
-			<affects>total</affects>
-			<reference>PU1:4</reference>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Power Based</name>
-			<cost type="percentage">-5</cost>
-			<affects>total</affects>
-			<reference>PY12:24</reference>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Cosmic</name>
-			<cost type="percentage">50</cost>
-			<affects>total</affects>
-			<reference>PU1:4</reference>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Ignore DR</name>
-			<cost type="percentage">300</cost>
-			<affects>total</affects>
-			<reference>PU1:4</reference>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Only One Skill</name>
-			<cost type="percentage">-80</cost>
-			<affects>total</affects>
-			<reference>PU1:4</reference>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Only Two Skills</name>
-			<cost type="percentage">-60</cost>
-			<affects>total</affects>
-			<reference>PU1:4</reference>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Only Three Skills</name>
-			<cost type="percentage">-40</cost>
-			<affects>total</affects>
-			<reference>PU1:4</reference>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Only Four Skills</name>
-			<cost type="percentage">-20</cost>
-			<affects>total</affects>
-			<reference>PU1:4</reference>
-		</modifier>
-		<reference>PU1:4</reference>
+		<name>Immunity to @Specific Disease@</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
 		<categories>
-			<category>Imbue</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Immunity to (@Specific Hazard/Poison/Disease@)</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:11</reference>
+		<categories>
+			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
@@ -2928,25 +8713,102 @@
 		</skill_bonus>
 	</advantage>
 	<advantage version="3">
-		<name>Immunity to (@Specific Hazard/Poison/Disease@)</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:11</reference>
+		<name>Imbue</name>
+		<type>Mental, Supernatural</type>
+		<modifier version="1" enabled="no">
+			<name>Imbue level 1</name>
+			<reference>PU1:4</reference>
+			<cost type="points">10</cost>
+			<affects>total</affects>
+			<notes>Novice imbuement skills available.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Imbue level 2</name>
+			<reference>PU1:4</reference>
+			<cost type="points">20</cost>
+			<affects>total</affects>
+			<notes>Intermediate (and easier) imbuement skills available.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Imbue level 3</name>
+			<reference>PU1:4</reference>
+			<cost type="points">40</cost>
+			<affects>total</affects>
+			<notes>Master (and easier) imbuement skills available.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Chi</name>
+			<reference>PU1:4</reference>
+			<cost type="percentage">-10</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Divine</name>
+			<reference>PU1:4</reference>
+			<cost type="percentage">-10</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Magical</name>
+			<reference>PU1:4</reference>
+			<cost type="percentage">-10</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Psionic</name>
+			<reference>PU1:4</reference>
+			<cost type="percentage">-10</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Power Based</name>
+			<reference>PY12:24</reference>
+			<cost type="percentage">-5</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Cosmic</name>
+			<reference>PU1:4</reference>
+			<cost type="percentage">50</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Ignore DR</name>
+			<reference>PU1:4</reference>
+			<cost type="percentage">300</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Only One Skill</name>
+			<reference>PU1:4</reference>
+			<cost type="percentage">-80</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Only Two Skills</name>
+			<reference>PU1:4</reference>
+			<cost type="percentage">-60</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Only Three Skills</name>
+			<reference>PU1:4</reference>
+			<cost type="percentage">-40</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Only Four Skills</name>
+			<reference>PU1:4</reference>
+			<cost type="percentage">-20</cost>
+			<affects>total</affects>
+		</modifier>
+		<reference>PU1:4</reference>
 		<categories>
-			<category>Perk</category>
+			<category>Imbue</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Immunity to @Specific Disease@</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Impatient</name>
+		<name>Imaginative</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
 		<reference>PU6:19</reference>
@@ -2955,7 +8817,219 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Improvised Weapons (@Combat Skill@)</name>
+		<name>Illumination</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:10</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Ill-Advised Hobby (@Subject@)</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:28</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Ignition</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:10</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Idealistic</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:19</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Hyper-Specialization (@Skill@; @Specialty@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:16</reference>
+		<notes>+5 to specialty</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Hungry</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:23</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Humble</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:19</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Huge Weapons (ST)</name>
+		<type>Physical, Exotic</type>
+		<levels>1</levels>
+		<points_per_level>1</points_per_level>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Huge Weapons (SM)</name>
+		<type>Physical, Exotic</type>
+		<levels>1</levels>
+		<points_per_level>1</points_per_level>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Horrible Hangovers</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:29</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Honest Face</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:4</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Hoarder</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:28</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>High-Pressure Intolerance</name>
+		<type>Physical, Exotic</type>
+		<base_points>-1</base_points>
+		<reference>PU6:12</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>High-Heeled Heroine</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>High-Frequency Hearing Loss</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:23</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>High Rejection Threshold</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Hedonist</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:28</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Heat Intolerance</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:25</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Headhunter</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Haughty Sneer</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<notes>Non-Verbal Savoir-Faire (High Society)</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Hated by @Group@</name>
+		<type>Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:33</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Hands Free (@Skill@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:16</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Grudge</name>
+		<type>Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:32</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Ground Guard</name>
 		<type>Physical</type>
 		<base_points>1</base_points>
 		<reference>PU2:6</reference>
@@ -2964,7 +9038,136 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Inaccessible Idioms</name>
+		<name>Grip Mastery (@Weapon@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Good with @Social Group@</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Good with @Animal@</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Glimpses of Clarity</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:19</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Generator</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:10</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Gangster Swagger</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<notes>Non-Verbal Streetwise</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Fur</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:10</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Friendly Drunk</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:29</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Friend</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<reference>PU2:18</reference>
+		<notes>@Details@</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Former Alcoholic</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:29</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Form Mastery (@Weapon@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Forgettable Face</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:4</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+		<prereq_list all="yes">
+			<advantage_prereq has="no">
+				<name compare="is">Unnatural Features</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+			<advantage_prereq has="no">
+				<name compare="is">Distinctive Features</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Forgetful</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:19</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Forbidden Word (@Word@)</name>
 		<type>Mental, Social</type>
 		<base_points>-1</base_points>
 		<reference>PU6:16</reference>
@@ -2973,7 +9176,103 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Inappropriate Manner (@Subject@)</name>
+		<name>Follow-Through (@Weapon Skill@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<notes>Intimidate as free action after kill/knockdown</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Focused Fury</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<notes>Combine Mighty Blows and All Out Attack</notes>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Focused (@Task@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Flourish (@Weapon Skill@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<notes>Intimidate at +4 with ready after kill/knockdown</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Flirtatious</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:28</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Feathers</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:10</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Fearsome Stare</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<notes>Non-Verbal Intimidation</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Favor Owed</name>
+		<type>Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:32</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Fatigues Easily Under Loads</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Fast Talker</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:16</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Fashion Disaster</name>
 		<type>Mental, Social</type>
 		<base_points>-1</base_points>
 		<reference>PU6:14</reference>
@@ -2982,161 +9281,17 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Inappropriate Manner (Aristocratic)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Inappropriate Manner (Oily)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Inappropriate Manner (Pushy)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Inappropriate Manner (Salacious)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Inappropriate Manner (Scummy)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Inappropriate Manner (Wishy-Washy)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Incompetence (@Skill@)</name>
+		<name>False Memory</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
-		<reference>PU6:31</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-		<prereq_list all="yes">
-			<skill_prereq has="no">
-				<name compare="is">@Skill@</name>
-				<specialization compare="is anything"></specialization>
-			</skill_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Insensitive</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:19</reference>
+		<reference>PU6:17</reference>
+		<notes>@Subject@</notes>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Interviews Badly</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Intolerance (@Small Group@)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:26</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Intuitive Repairman (@Item@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:9</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Involuntary Utterance</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:16</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Iron Body Parts (Iron Arms)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Iron Body Parts (Iron Hands)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Iron Body Parts (Iron Legs)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Iron Body Parts (Iron Neck)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Job Hunter</name>
+		<name>Eye for Distance</name>
 		<type>Mental</type>
 		<base_points>1</base_points>
 		<reference>PU2:13</reference>
@@ -3145,1015 +9300,24 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Layabout</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:19</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Lazy Skill (@Attribute@-based @Skill@)</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:31</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-		<prereq_list all="yes">
-			<skill_prereq has="yes">
-				<name compare="is">@Skill@</name>
-				<specialization compare="is anything"></specialization>
-			</skill_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Legalistic</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:9</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>License (@Type@)</name>
-		<type>Social</type>
-		<base_points>1</base_points>
-		<reference>PU2:18</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Like (@Subject@)</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:26</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Limited Camouflage (@Environment@)</name>
+		<name>Extreme Sexual Dimorphism</name>
 		<type>Physical, Exotic</type>
 		<base_points>1</base_points>
-		<reference>PU2:11</reference>
+		<reference>PU2:10</reference>
+		<notes>+1 to attempts to identify you, -1 to attempts to remain anonymous.</notes>
 		<categories>
 			<category>Perk</category>
 		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Limited Colorblindness</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:23</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Literal-Minded</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:19</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Long Fingers</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:11</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Looks Good in Uniform</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Loud Voice</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:16</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Low Rejection Threshold</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Low-Frequency Hearing Loss</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:23</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Low-Pressure Intolerance</name>
-		<type>Physical, Exotic</type>
-		<base_points>-1</base_points>
-		<reference>PU6:12</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Magic School Familiarity (@School@)</name>
-		<type>Mental, Social, Supernatural</type>
-		<base_points>1</base_points>
-		<reference>PU2:19</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Masked</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Math-Shy</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:31</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Methodical</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:19</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Mild Dyslexia</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:31</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Mind-Numbing Magnetism</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Minor Addiction (@Subject@)</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:29</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Minor Alcoholism</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:29</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Minor Handicap (@Subject@)</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:23</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Missing Teeth</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:23</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Missing Toes</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:23</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Name-Bound</name>
-		<type>Supernatural</type>
-		<base_points>-1</base_points>
-		<reference>PU6:34</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Named Possession (@Name@)</name>
-		<type>Social, Supernatural</type>
-		<base_points>1</base_points>
-		<reference>PU2:19</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Nano-Fever</name>
-		<type>Physical, Exotic</type>
-		<base_points>-1</base_points>
-		<reference>PU6:12</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Natural Pockets</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<notes>@Details@</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Naval Training</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Neck Control (@Unarmed Striking Skill@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Nervous Stomach</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:25</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Neutered</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:23</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Never raises voice</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:30</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>No Degeneration in Zero-G</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:11</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>No Hangover</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>No Nuisance Rolls (@Task@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:16</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>No Visible Damage</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:11</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="is">Unkillable</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Nostalgic</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:19</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Nosy</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Obscure True Name</name>
-		<type>Social, Supernatural</type>
-		<base_points>1</base_points>
-		<reference>PU2:19</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Obsession (@Subject@)</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:29</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Obvious</name>
-		<type>Physical, Exotic</type>
-		<base_points>-1</base_points>
-		<reference>PU6:12</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Odious Personal Habit</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Off-Hand Training (@Skill@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:16</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Office (@Type@)</name>
-		<type>Social</type>
-		<base_points>1</base_points>
-		<reference>PU2:18</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>One-Armed Bandit (@Guns Skill@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>One-Task Wonder (@Task@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:17</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>One-Way Fluency (@Language@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>One-Way Literacy (@Language@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Overcautious Habit</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:30</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Overspecialization (@Skill@)</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:31</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-		<prereq_list all="yes">
-			<skill_prereq has="yes">
-				<name compare="is">@Skill@</name>
-				<specialization compare="is anything"></specialization>
-				<level compare="at least">1</level>
-			</skill_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Overweight</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:23</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Pain-Sensitive</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:23</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Pants-Positive Safety</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Parthenogenesis</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:11</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Passing Appearance (@Group@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:4</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Passing Appearance (Androgynous)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:4</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Passing Appearance (Passing Complexion)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:4</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Patience of Job</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Peg-Leg Fighting</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="starts with">Lame</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Penetrating Voice</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Perfectionist</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Perfume</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:11</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Periscope</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:11</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Permit (@Type@)</name>
-		<type>Social</type>
-		<base_points>1</base_points>
-		<reference>PU2:18</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Personality Change</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Pet (@Type@)</name>
-		<type>Social</type>
-		<base_points>1</base_points>
-		<reference>PU2:18</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Philosophical Belief (@Subject@)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:8</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Photogenic</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:4</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Photosensitivity</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Pistol-Fist (@Pistol Skill@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Poor Night Vision</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Posh</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Positive Secret</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:33</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Power Grappling</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Practical Joker</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:30</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Preferred Looks</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:26</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Preferred Tactics</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:26</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Pressure-Tolerant Lungs</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:11</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Pretense</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:33</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Proud</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Purpose (@Purpose@)</name>
-		<type>Supernatural</type>
-		<base_points>1</base_points>
-		<reference>PU2:19</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Quick-Sheathe (@Weapon@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Quick-Swap (@Weapon@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Rapid Retraction (Bites)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Rapid Retraction (Kicks)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Rapid Retraction (Punches)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Razor Kicks</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Reach Mastery (@Weapon@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<notes>Let you change reach as a free action</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Record-Keeper</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:29</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Red Tape</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:33</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Religious Belief (@Subject@)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:8</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Reproductive Control (Fertility Control)</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:12</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Reproductive Control (Reabsorption)</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:12</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Residual Personality</name>
-		<type>Supernatural</type>
-		<base_points>-1</base_points>
-		<reference>PU6:34</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Resistant to @Specific Poison@</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<notes>+3 to resist</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Responsible</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Responsive</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Rest in Pieces</name>
-		<type>Supernatural</type>
-		<base_points>1</base_points>
-		<reference>PU2:19</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Restless Sleeper</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Restricted Casting Style</name>
-		<type>Supernatural</type>
-		<base_points>-1</base_points>
-		<reference>PU6:34</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Rinse</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:12</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Risk-Taking Behavior</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:30</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Robust (@Sense@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Rule of 15</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Rule of 15 (@Class of skills@)</name>
-		<type>Supernatural</type>
-		<base_points>-1</base_points>
-		<reference>PU6:34</reference>
-		<notes>Requires at least one applicable skill at 16+.</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Rule of 17 (@Skill@)</name>
-		<type>Supernatural</type>
+		<skill_bonus>
+			<name compare="is">Sex Appeal</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount>1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Extra Option (@Rule@)</name>
+		<type></type>
 		<base_points>1</base_points>
 		<reference>PU2:20</reference>
 		<categories>
@@ -4161,7 +9325,7 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Rules Exclusion (@Rule@)</name>
+		<name>Extra Drawback (@Rule@)</name>
 		<type></type>
 		<base_points>-1</base_points>
 		<reference>PU6:21</reference>
@@ -4170,54 +9334,18 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Rules Exemption (@Rule@)</name>
-		<type></type>
-		<base_points>1</base_points>
-		<reference>PU2:20</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sacrificial Parry (@Weapon@)</name>
+		<name>External Mood Influence</name>
 		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
+		<base_points>-1</base_points>
+		<reference>PU6:18</reference>
+		<notes>@Subject@</notes>
 		<categories>
-			<category>Perk</category>
+			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Sanitized Metabolism</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:12</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sartorial Integrity</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Scales</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:12</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sea Legs</name>
-		<type>Mental</type>
+		<name>Extended Hearing (Low)</name>
+		<type>Physical</type>
 		<base_points>1</base_points>
 		<reference>PU2:14</reference>
 		<categories>
@@ -4225,451 +9353,203 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Secret Knowledge (@Skill@)</name>
-		<type></type>
+		<name>Extended Hearing (High)</name>
+		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:20</reference>
+		<reference>PU2:14</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Secret Powers</name>
+		<name>Expensive Habit (@Subject@)</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:28</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Exotic Weapon Training (@Weapon@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Exotic Equipment Training (@Equipment@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:9</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Ex-Cop</name>
+		<type>Social</type>
+		<levels>1</levels>
+		<points_per_level>1</points_per_level>
+		<reference>PU2:18</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Epitome (@Subject@)</name>
+		<type>Mental/Physical, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:14</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Emeritus Professor</name>
+		<type>Social</type>
+		<levels>1</levels>
+		<points_per_level>1</points_per_level>
+		<reference>PU2:18</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Efficient (@Skill@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:16</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Eavesdropper</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:28</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Easily Winded</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Easily Mistaken Sex</name>
+		<type>Physical, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:14</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dull Taste and Smell</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dull Taste</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dull Smell</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dull</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:18</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dual Ready (@Single Handed Weapon Skill@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dual Identity</name>
 		<type>Social</type>
 		<base_points>-1</base_points>
 		<reference>PU6:33</reference>
-		<notes>@Subject@</notes>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Secret Styles (@Move Name@)</name>
+		<name>Drunken Fighting</name>
 		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:7</reference>
+		<reference>PU2:5</reference>
 		<categories>
 			<category>Cinematic</category>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Secretive</name>
+		<name>Dreamer</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:18</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dramatic Death</name>
+		<type>Supernatural</type>
+		<base_points>1</base_points>
+		<reference>PU2:19</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dorky</name>
 		<type>Mental, Social</type>
 		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
+		<reference>PU6:18</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Self-Imposed Limit</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:27</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Serious</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sexless</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:23</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sexy Pose</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<notes>Non-Verbal Sex Appeal</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Shaky Hands</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sharpens weapons at every opportunity</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:30</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Shield-Wall Training</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Shocking Affectation</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Shoves and Tackles (@Long Weapon@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Show-Off (@Skill@)</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:32</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-		<prereq_list all="yes">
-			<skill_prereq has="yes">
-				<name compare="is">@Skill@</name>
-				<specialization compare="is anything"></specialization>
-				<level compare="at least">1</level>
-			</skill_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Skill Adaptation (@Specific skill use@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:17</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Skintight</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sleep of the Dead</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sleeptalker</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sleepy Drinker</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:29</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sleepyhead</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Slightly Unusual Biochemistry</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Slow Reflexes</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Soft Spot (@Group@)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:27</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Special Exercises (@Attribute, Characteristics or Advantage@)</name>
+		<name>Doodad</name>
 		<type></type>
 		<levels>1</levels>
 		<points_per_level>1</points_per_level>
-		<reference>PU2:21</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Special Setup (@New setup &gt; Technique@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Spell Signature</name>
-		<type>Supernatural</type>
-		<base_points>-1</base_points>
-		<reference>PU6:34</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Spell Susceptibility (@Spell@)</name>
-		<type>Supernatural</type>
-		<base_points>-1</base_points>
-		<reference>PU6:34</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Spirit Contract (@Patron@)</name>
-		<type>Social, Supernatural</type>
-		<base_points>1</base_points>
-		<reference>PU2:20</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Staid</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Standard Operating Procedure (Back to the Wall)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Standard Operating Procedure (Energizer)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Standard Operating Procedure (Full Tank)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Standard Operating Procedure (Last Man Out)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Standard Operating Procedure (Off-Screen Reload)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Standard Operating Procedure (On Alert)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Stereotype (@Subject@)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:16</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Striking Surface</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:12</reference>
-		<notes>Requires DR 3+ without Flexible, Force Field, or Tough Skin.</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="is">Damage Resistance</name>
-				<notes compare="is anything"></notes>
-				<level compare="at least">3</level>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Strongbow</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Style Familiarity (@Style@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Substance Intolerance (@Subject@)</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:25</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Successful at @Ability@</name>
-		<type></type>
-		<base_points>-1</base_points>
-		<reference>PU6:21</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Suit Familiarity (@Environment Suit skill@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:9</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sunburns Easily</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Supernatural Dislike</name>
-		<type>Supernatural</type>
-		<base_points>-1</base_points>
-		<reference>PU6:34</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Supernatural Features</name>
-		<type>Supernatural</type>
-		<base_points>-1</base_points>
-		<reference>PU6:34</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Superstition</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:9</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Supersuit</name>
-		<type>Physical, Supernatural</type>
-		<base_points>1</base_points>
 		<reference>PU2:9</reference>
 		<categories>
 			<category>Cinematic</category>
@@ -4677,6240 +9557,7 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Sure-Footed (@Surface@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:8</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sure-Footed (Ice)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:8</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sure-Footed (Sand)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:8</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sure-Footed (Slippery)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:8</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sure-Footed (Snow)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:8</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sure-Footed (Uneven)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:8</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sure-Footed (Water)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:8</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Susceptible to @Item@</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Suspicious</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Swinging</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:16</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Symbol-Shy</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:31</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Taboo Traits (@Subject@)</name>
-		<type></type>
-		<base_points>-1</base_points>
-		<reference>PU6:21</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Academic)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Students and teachers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>+1/Level to any roll that benefits from Eidetic Memory</notes>
-		</modifier>
-		<reference>PU3:6</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Public Speaking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Research</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Speed-Reading</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Teaching</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Writing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Alien Friend)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Aliens</notes>
-		</modifier>
-		<reference>PU3:6</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Diplomacy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is">Xenology</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Anthropology</name>
-			<specialization compare="is">@Alien@</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">History</name>
-			<specialization compare="is">@Alien@</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is">@Alien@</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Allure)</name>
-		<type>Physical</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<reference>PU3:6</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Dancing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Erotic Art</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Makeup</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sex Appeal</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Singing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Animal Friend)</name>
-		<type>Physical</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<reference>PU3:6</reference>
-		<notes>Reaction Bonus: All ordinary animals</notes>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Animal Handling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Falconry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Packing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Riding</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Teamster</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Veterinary</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Antiquary)</name>
-		<type>Physical</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus: Devotees of the old and beautiful.</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Benefit</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:6</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Architecture</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Connoisseur</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Heraldry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">History</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Literature</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Research</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Artificer)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Employers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Eliminate -1/level to a skill with success on another to improvise tools; Apply to Enigmatic Device Table rolls and other unskilled tech rolls.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:6</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">armoury</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">carpentry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">electrician</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">electronics repair</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">engineer</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">machinist</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">masonry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">mechanic</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">smith</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Bard)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Audiences and fellow bards</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to first influence roll made against one or more audience members after a successful performance.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:6</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">heraldry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">literature</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">musical influence</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">poetry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">public speaking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">singing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Beastmaster)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Animals</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">2</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:6</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">animal handling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">disguise</name>
-			<specialization compare="is anything">animals</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">falconry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">flight</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">hidden lore</name>
-			<specialization compare="is">lycanthropes</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">mimicry</name>
-			<specialization compare="is">animal sounds</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">mimicry</name>
-			<specialization compare="is">bird calls</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">mount</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">naturalist</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">packing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">riding</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">teamster</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">veterinary</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount>1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Born Entertainer)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Crowds</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>+1/level to first influence roll made against one or more audience members after a successful performance.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:6</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">acting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">dancing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">performance</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">public speaking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">singing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">stage combat</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Born Sailor)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Sailors</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to resist seasickness and reduce unfamiliarity penalties for system on an appropriate boat or ship</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:13</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Boating</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Knot-Tying</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Meteorology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Navigation</name>
-			<specialization compare="is">Sea</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Seamanship</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shiphandling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Weather Sense</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="no">
-				<name compare="is">Talent (Mariner)</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Born Soldier)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Those you serve with or command</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Reduce chance of impersonal battlefield hazards</notes>
-		</modifier>
-		<reference>PU3:12</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Leadership</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Savoir-Faire</name>
-			<specialization compare="is anything">Military</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Scrounging</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Soldier</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Tactics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Born Spacer)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Professional Spacers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>+1/Level to ST for zero G push off.  Reduce penalty for unfamiliar spacecraft.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:7</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Aerobatics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Free Fall</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Navigation</name>
-			<specialization compare="is">Space</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Piloting</name>
-			<specialization compare="is">High-Performance Spacecraft</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Piloting</name>
-			<specialization compare="is">Low-Performance Spacecraft</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Piloting</name>
-			<specialization compare="is">Aerospace</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Spacer</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Vacc Suit</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Born Tactician)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Anyone you serve with or command</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to initiative rolls if leader</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-2</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:12</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">History</name>
-			<specialization compare="contains">Military</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Intelligence Analysis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Leadership</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Savoir-Faire</name>
-			<specialization compare="is">Military</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Soldier</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Strategy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Tactics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is anything">Military Science</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Born to Be Wired)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Hackers; people buying stock in your dot-com.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>-1/level less-severe penalties from Familiarity (p. B169) for unfamiliar computer equipment, and/or success at Computer Hacking or Computer Programming lets you improvise code that removes -1/level from the penalty for not having proper software for a task that requires it (p. B345).</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:8</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Computer Hacking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Computer Operation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Computer Programming</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Cryptography</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Electronics Repair (Computers)</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill (Computer Security)</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Born War Leader)</name>
-		<type>Physical</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<reference>DF1:14,PU3:12</reference>
-		<categories>
-			<category>Advantage</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">leadership</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">strategy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="starts with">tactics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">intelligence analysis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">savoir-faire</name>
-			<specialization compare="is">military</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Business Acumen)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus: Anyone with whom you do business.</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-2</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:7</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Accounting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Administration</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Economics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Finance</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Gambling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Market Analysis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Merchant</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Propaganda</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Chi Talent)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>15</points_per_level>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">5</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:7</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Autohypnosis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Blind Fighting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Body Control</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Breaking Blow</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Breath Control</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Esoteric Medicine</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Flying Leap</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Immovable Stance</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Invisibility Art</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Kiai</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Light Walk</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mental Strength</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mind Block</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Parry Missile Weapons</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Power Blow</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pressure Points</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pressure Secrets</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Push</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Throwing Art</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Zen Archery</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Chi Talent)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>15</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus: None</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-		</modifier>
-		<reference>PU3:7</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Autohypnosis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Blind Fighting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Body Control</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Breaking Blow</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Breath Control</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Esoteric Medicine</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Flying Leap</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Immovable Stance</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Invisibility Art</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Kiai</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Light Walk</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mental Strength</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mind Block</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Parry Missile Weapons</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Power Blow</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pressure Points</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pressure Secrets</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Push</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Throwing Art</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Zen Archery</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Circuit Sense)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Anyone for whom you use your skills</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>-1/level less-severe penalties from Familiarity (p. B169) &#8211; which can run to -10 in certain cases (see p. B189) &#8211; when using any skill to operate unfamiliar gear that runs on electricity.</notes>
-		</modifier>
-		<reference>PU3:8</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Electrician</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Electronics Operation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Electronics Repair</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Engineer (Electrical and Electronics)</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Close to Heaven)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Any fellow &#8220;religious professional&#8221;</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>IQ-4+Level to notice omens and blessed items</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:8</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Meditation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Religious Ritual</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Theology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Ritual Magic</name>
-			<specialization compare="is">@Religion@</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Symbol Drawing</name>
-			<specialization compare="is">@Religion@</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Exorcism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Close to Hell)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Demons</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:8</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Exorcism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is">Demons</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Occultism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is">Demons</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Religious Ritual</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Theology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Close to the Earth)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Those who respect nature</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>IQ-4+Level to notice disturbances in nature</notes>
-		</modifier>
-		<reference>PU3:8</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is">Elementals</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Naturalist</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Religious Ritual</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Theology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Weather Sense</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is">Faeries</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is">Nature Spirits</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Clown)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Audiences, circus performers, vaudevillians, and fellow fools</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>+1/level to first influence roll made against one or more audience members after a successful performance.</notes>
-		</modifier>
-		<reference>PU3:8</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Acrobatics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Dancing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fire Eating</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hobby Skill</name>
-			<specialization compare="is">Juggling</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Makeup</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mimicry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Performance</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Singing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sleight of Hand</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Ventriloquism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Computer Wizard)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Computer professionals and AIs</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Reduce Familiarity penalties for computers. Roll Hacking/Programming to improvise software to reduce equipment penalty.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:9</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Computer Operation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Computer Programming</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Electronics Operation</name>
-			<specialization compare="is">Communications</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Electronics Operation</name>
-			<specialization compare="is">Media</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Electronics Repair</name>
-			<specialization compare="is">Computers</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is">Computer Security</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is">AI</specialization>
-			<category compare="is anything"></category>
-			<amount>1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Craftiness)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus: None</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:9</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Camouflage</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Disguise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Holdout</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shadowing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Stealth</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Acting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Cultural Chameleon)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Other cultures in their lands</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:9</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Anthropology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Diplomacy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Gesture</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Linguistics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sociology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Cunning Folk)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Local peasantry, clients, and acolytes.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Benefit</name>
-			<cost type="points">-2</cost>
-			<affects>levels only</affects>
-			<notes>A roll at IQ-4, +1/level of Cunning Folk, to notice anything odd &#8211; curses, blights, faeries in the basement, etc. &#8211; that happens to animals, crops, or people in an area where you&#8217;ve lived for at least (6 - Cunning Folk level) months.</notes>
-		</modifier>
-		<reference>PU3:9</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Animal Handling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fortune-Telling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Herb Lore</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Naturalist</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Occultism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Poisons</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Veterinary</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Weather Sense</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Cyberneticist)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Other computer professionals, AI systems, and robots</notes>
-		</modifier>
-		<reference>PU3:9</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Computer Hacking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Computer Operation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Computer Programming</name>
-			<specialization compare="is"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Computer Programming</name>
-			<specialization compare="is">AI</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Electronics Repair</name>
-			<specialization compare="is">Computers</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Devotion)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Coreligionists and sympathizers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to will to resist "evil influences"</notes>
-		</modifier>
-		<reference>PU3:9</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Autohypnosis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Exorcism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Meditation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Religious Ritual</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Driver's Reflexes)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Passengers; gamblers betting on you at the Grand Prix.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>+1/level on Per rolls to notice dangers in the path of your ride: running children, oncoming vehicles, landmines...</notes>
-		</modifier>
-		<reference>PU3:10</reference>
-		<categories>
-			<category>Advantage</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Boating</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Driving</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Piloting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Submarine</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Dungeon Artificer)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Potential Buyers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Roll appropriate skill to scrounge equipment for other covered skills and apply level against the penalty.  Shift rolls to avoid ill effects from mysterious artifacts by level in either direction.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:10</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Alchemy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Armoury</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Engineer</name>
-			<specialization compare="is">Gadgets</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fast-Draw</name>
-			<specialization compare="is">Gadgets</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Scrounging</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Traps</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Elder Gift)</name>
-		<type>Mental, Exotic, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Elder Things</notes>
-		</modifier>
-		<reference>PU3:6</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Alchemy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Occultism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Thaumatology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Empath)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>IQ-4+level roll as for Empathy</notes>
-		</modifier>
-		<reference>PU3:10</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Body Language</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Detect Lies</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Diplomacy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fortune-Telling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Explorer)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Fellow explorers and backers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Reduce distance and area class penalties for all skills</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">0</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:10</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Area Knowledge</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Cartography</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Geography</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mathematics</name>
-			<specialization compare="is">Surveying</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Navigation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Forceful Chi)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>15</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Honourable opponents, Hard stylists, Lovers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to be heard or to Intimidation after using a covered skill</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:7</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Breaking Blow</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Erotic Art</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Flying Leap</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hypnotic Hands</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hypnotism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Invisibility Art</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Kiai</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Power Blow</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Precognitive Parry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pressure Points</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pressure Secrets</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Push</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Throwing Art</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Zen Archery</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Forensics Whiz Kid)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Crime-lab employers and detectives</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to Per to spot clues when no skill applies</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Chemistry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Criminology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Diagnosis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Forensics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Research</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Forest Guardian)</name>
-		<type>Mental, Exotic, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Druids, Faeries, and bunnies</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to notice intruders, etc in woodland where you've lived from 6-level months.</notes>
-		</modifier>
-		<reference>PU3:10</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Bow</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Camouflage</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fast-Draw</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Stealth</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Survival</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="ends with">Elf</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Gifted Artist)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Buyers and Critics</notes>
-		</modifier>
-		<reference>PU3:10</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Artist</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Jeweler</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Leatherworking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Photography</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sewing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Goodwife)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Beneficiaries, prospective spouses, other housewives</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to defaults made in your own home to repair, maintain, and protect it.</notes>
-		</modifier>
-		<reference>PU3:10</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Cooking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Diagnosis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Gardening</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Housekeeping</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sewing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Green Thumb)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Gardeners and Sentient plants</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to rolls to survive made by plants in your care.</notes>
-		</modifier>
-		<reference>PU3:11</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Biology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Farming</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Gardening</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Herb Lore</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Naturalist</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Healer)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Patients</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to HT rolls for a specific patient and condition if treated full time.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:11</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Diagnosis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Esoteric Medicine</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">First Aid</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pharmacy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Physician</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Physiology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Surgery</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Veterinary</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="no">
-				<name compare="is">Talent (Healer)</name>
-				<notes compare="contains">Modern</notes>
-				<level compare="at least">1</level>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Healer)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Patients</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to HT rolls for a specific patient and condition if treated full time.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:11</reference>
-		<notes>Modern</notes>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Diagnosis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Esoteric Medicine</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">First Aid</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pharmacy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Physician</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Physiology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Surgery</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Veterinary</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Electronics Operation</name>
-			<specialization compare="is">Medical</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is">Epidemiology</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="no">
-				<name compare="is">Talent (Healer)</name>
-				<notes compare="does not contain">Modern</notes>
-				<level compare="at least">1</level>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Hot Pilot)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Other Pilots</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Reduce penalties for unfamiliar systems of vehicles you have Piloting skill for</notes>
-		</modifier>
-		<reference>PU3:11</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Gunner</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Navigation</name>
-			<specialization compare="is">Air</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Navigation</name>
-			<specialization compare="is">Space</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Piloting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Impersonator)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus in contests against covered skills</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:11</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Acting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Body Language</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Disguise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mimicry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Savoir-Faire</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Streetwise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Inner Balance)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>15</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Pacifists, Ascetics, Soft stylists</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to resist mundane disease</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:7</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Autohypnosis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Blind Fighting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Body Control</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Body Language</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Body Sense</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Breath Control</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Dreaming</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Immovable Stance</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Light Walk</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Lizard Climb</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Meditation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mental Strength</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mind Block</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sensitivity</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Intuitive Admiral (Sea))</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Anyone you serve with or command</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to initiative roll if leader</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-2</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:12</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is">Military Science</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">History</name>
-			<specialization compare="ends with">Military</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Intelligence Analysis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Leadership</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Savoir-Faire</name>
-			<specialization compare="is">Military</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shiphandling</name>
-			<specialization compare="is">Ship</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shiphandling</name>
-			<specialization compare="is">Submarine</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Seamanship</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Strategy</name>
-			<specialization compare="is">Sea</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Submariner</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Intuitive Admiral (Space))</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Anyone you serve with or command</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to initiative roll if leader</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-2</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:12</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is">Military Science</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">History</name>
-			<specialization compare="ends with">Military</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Intelligence Analysis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Leadership</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Savoir-Faire</name>
-			<specialization compare="is">Military</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shiphandling</name>
-			<specialization compare="is">Spaceship</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shiphandling</name>
-			<specialization compare="is">Starship</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Spacer</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Strategy</name>
-			<specialization compare="is">Space</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Intuitive Statesman)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Political Parties seeking candidates, those who put you in power</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to influence rolls to be chosen over another for a job or posting, or to cover up a failure with a covered skill.</notes>
-		</modifier>
-		<reference>PU3:11</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Administration</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Current Affairs</name>
-			<specialization compare="is">Headline News</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Current Affairs</name>
-			<specialization compare="is">People</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Current Affairs</name>
-			<specialization compare="is">Politics</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Diplomacy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Economics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Law</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Leadership</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Politics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Propaganda</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Public Speaking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Jack of All Trades)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<reference>PU3:11</reference>
-		<notes>Bonus to all defaults from attributes</notes>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Mariner)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Seafarers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to resist seasicknes and reduce unfamiliarity penalties for system on an appropriate boat or ship</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-3</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:13</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Boating</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Freight Handling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Knot-Tying</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Meteorology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Navigation</name>
-			<specialization compare="is">Sea</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Seamanship</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shiphandling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Weather Sense</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="no">
-				<name compare="is">Talent (Born Sailor)</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Master Builder)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Workers on projects, prospective employers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to avoid common workplace hazards, even if used as traps</notes>
-		</modifier>
-		<reference>PU3:11</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Architecture</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Carpentry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Engineer</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Forced Entry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Masonry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Mathematical Ability)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Engineers and scientists</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to resist deception involving numbers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-2</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:12</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Accounting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Astronomy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Cryptography</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Engineer</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Finance</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Market Analysis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mathematics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Physics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Memetics)</name>
-		<type>Mental, Exotic</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Other memeticists who see you working</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to resist Brainwashing, Fast-Talk, and Propaganda</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">2</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:12</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Brainwashing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Diplomacy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is anything">Memetics</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fast-Talk</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Interrogation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Leadership</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Merchant</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Politics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Propaganda</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sociology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Teaching</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Mesmerist)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>The foolish and weak-minded.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>+1/level to resist any of the affected skills.</notes>
-		</modifier>
-		<reference>PU3:12</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Autohypnosis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Brainwashing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Captivate</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Gesture</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hypnotism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Intimidation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Musical Influence</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Persuade</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Suggest</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sway Emotions</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Mr. Smash)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to intimidate when victim at your mercy and you are threatening with a covered weapon</notes>
-		</modifier>
-		<reference>PU3:13</reference>
-		<notes>Covers Forced-Entry, but only when used with a swung Two Handed weapon.</notes>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Polearm</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Two-Handed Axe/Mace</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Two-Handed Flail</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Two-Handed Sword</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Musical Ability)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Audiences and Critics</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to first influence roll made against one or more audience members after a successful performance.</notes>
-		</modifier>
-		<reference>PU3:13</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Group Performance</name>
-			<specialization compare="is">Conducting</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Musical Composition</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Musical Influence</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Musical Instrument</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Singing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Natural Athlete)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Sports fans, coaches, and recruiters</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to HT to recover from injuries resulting from failures with covered skills</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:13</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Bicycling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Breath Control</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hiking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Jumping</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Lifting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Running</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Skating</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Skiing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sports</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Swimming</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Throwing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Natural Copper)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Police and PIs</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to unskilled Per rolls to notice clues, and to all rolls to use Intuition</notes>
-		</modifier>
-		<reference>PU3:13</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Body Language</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Criminology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Detect Lies</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Intelligence Analysis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Interrogation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Observation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Savoir-Faire</name>
-			<specialization compare="is anything">Police</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Search</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shadowing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Streetwise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Natural Diver)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Expert divers and aquatic beings</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to HT for breath holding time and resisting the Bends, Nitrogen Narcosis, etc.</notes>
-		</modifier>
-		<reference>PU3:13</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Aquabatics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Diving Suit</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Scuba</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is anything">Submarine</name>
-			<specialization compare="is">Free-Flooding Sub</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Swimming</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Natural Scientist)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Scientists and those impressed by "smart people"</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Reduce TL and familiarity penalties for gear examined for an hour with a covered skill</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:13</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Astronomy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Chemistry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is anything">Hydrology</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is anything">Natural Philosophy</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Geology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mathematics</name>
-			<specialization compare="is anything">Applied</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mathematics</name>
-			<specialization compare="is anything">Statistics</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mathematics</name>
-			<specialization compare="is anything">Surveying</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Metallurgy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Meteorology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Paleontology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Physics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pysiology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Ninja Talent)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1" enabled="no">
-			<name>Power Talent</name>
-			<cost type="points">5</cost>
-			<affects>levels only</affects>
-			<reference>DF12:4</reference>
-		</modifier>
-		<reference>PU3:7</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Blind Fighting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hypnotism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Invisibility Art</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Light Walk</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mental Strength</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Occultist)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Students of the arcane, gullible college students, monster-hunters.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Benefit</name>
-			<cost type="points">2</cost>
-			<affects>levels only</affects>
-			<notes>+1/level to Fright Checks caused by supernatural beings and effects, and by reading sanity-destroying tomes (because you know what to expect).</notes>
-		</modifier>
-		<reference>PU3:14</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Alchemy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Anthropology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Archaeology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Exorcism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">History</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Linguistics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Literature</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Occultism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Research</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Ritual Magic</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Thaumatology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Outdoorsman)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Explorers and nature lovers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to HT rolls to avoid harm from failure of covered skills</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-3</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:14</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Camouflage</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fishing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mimicry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Naturalist</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Navigation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Survival</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Tracking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Parapsychologist)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Psis and beleivers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to resist powers that have been examined with covered skills</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:14</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Electronics Operation</name>
-			<specialization compare="is anything">Medical</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Electronics Operation</name>
-			<specialization compare="is anything">Psychotronics</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Electronics Operation</name>
-			<specialization compare="is anything">Scientific</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is anything">Psionics</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hypnotism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Occultism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Physics</name>
-			<specialization compare="is anything">Paraphysics</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Pickaxe Penchant)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Miners</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to will for Extra Effort when digging, HT on failure at such, and all rolls to avoid disasters in mines</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">0</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:14</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Axe/Mace</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Forced Entry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Prospecting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Thrown Weapon</name>
-			<specialization compare="is anything">Axe/Mace</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Two-Handed Axe/Mace</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="is">Dwarf</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Poet)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Readers and listeners of your work; literati.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>+1/level to the first Influence roll (p. B359) of any kind made on an audience member (or several of them as a group) after a successful performance.</notes>
-		</modifier>
-		<reference>PU3:14</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Connoisseur (Literature)</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Literature</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Poetry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Public Speaking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Writing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Pop Culture Maven)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Obsessive pop culture devotees</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to Influence or Carousing to demonstrate you are "cool".</notes>
-		</modifier>
-		<reference>PU3:14</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Connoisseur</name>
-			<specialization compare="is anything">Virtual Reality Arts</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Current Affairs</name>
-			<specialization compare="is anything">People</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Current Affairs</name>
-			<specialization compare="is anything">Popular Culture</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Current Affairs</name>
-			<specialization compare="is anything">Sports</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is anything">Memetics</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Psientist)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Psis</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to self control rolls after a successful Meditation, Mental Strength, or Mind Block</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:15</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Hypnotism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Meditation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mental Strength</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mind Block</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is">Psionics</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is">Psionics</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Sage)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Scholars, students, and people who consult you</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to IQ defaults to non-covered skills for general knowledge only</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">2</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:15</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Archaeology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Geography</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Heraldry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">History</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Law</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Literature</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Occultism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Philosophy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Research</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Theology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Seafarer)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Sailors, pirates, and aquatic races sympathetic to sea travel</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to resist seasicknes and reduce unfamiliarity penalties for system on an appropriate boat or ship. Bonus to Carousing and Streetwise in port towns.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:14</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Boating</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fishing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Knot-Tying</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Meteorology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Weather Sense</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Navigation</name>
-			<specialization compare="is anything">Sea</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Seamanship</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Survival</name>
-			<specialization compare="is anything">Island/Beach</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Swimming</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Thrown Weapon</name>
-			<specialization compare="is anything">Harpoon</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="no">
-				<name compare="is">Talent (Born Sailor)</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-			<advantage_prereq has="no">
-				<name compare="is">Talent (Mariner)</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Smooth Operator)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>15</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Con artists, politicians, salesmen, etc. &#8211; but only if you aren&#8217;t trying to manipulate them.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to resist covered skills</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-2</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:15</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Acting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Carousing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Detect Lies</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Diplomacy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fast-Talk</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Intimidation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Leadership</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Panhandling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Politics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Public Speaking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Savoir-Faire</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sex Appeal</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Streetwise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Social Scientist)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Social and political thinkers, theorists, and activists</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to Acting, Disguise, and Fast-Talk to pass as a member of another political/religious group.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:15</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Anthropology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Archaeology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Criminology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Economics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is">Political Science</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Geography</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">History</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Philosophy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sociology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Theology</name>
-			<specialization compare="is">Comparative</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Spirit-Talker)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Spirits</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:15</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Exorcism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fortune-Telling</name>
-			<specialization compare="is anything">Augury</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fortune-Telling</name>
-			<specialization compare="is anything">Dream Interpretation</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is anything">Spirits</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Meditation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Occultism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Theology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Stalker)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Hunters, trackers, etc.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>+1/level to Per rolls to keep track of a specific quarry you&#8217;ve already spotted using other skills.</notes>
-		</modifier>
-		<reference>PU3:15</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Camouflage</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hiking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Navigation (Land)</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Stealth</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Tracking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Strangler)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to Per to notice people sneaking within arms reach of you</notes>
-		</modifier>
-		<reference>PU3:15</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Brawling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Stealth</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Tracking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Wrestling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="is">Throttler</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Street Smarts)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Other street operators</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to notice inner city dangers and scams and to Tracking in built up areas.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:16</reference>
-		<notes>Familiarity with a new city for city specific skills requires 6-level months</notes>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Area Knowledge</name>
-			<specialization compare="is">@City@</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Current Affairs</name>
-			<specialization compare="is">@City@</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Law</name>
-			<specialization compare="is">@City@</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Merchant</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Panhandling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Scrounging</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shadowing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Streetwise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Urban Survival</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="no">
-				<name compare="is">Talent (Street-Smart)</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Street-Smart)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Shady characters in town.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to notice inner city dangers and scams and to Tracking in built up areas.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Merchant</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Panhandling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Scrounging</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shadowing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Streetwise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Urban Survival</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="no">
-				<name compare="is">Talent (Street Smarts)</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Strong Chi)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Other martial artists, especially potential masters or students.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>+1/level on rolls to be heard (compare Penetrating Voice, p. B101), and to Intimidation attempts made after using one of the affected skills.</notes>
-		</modifier>
-		<reference>PU3:8</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Breaking Blow</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Flying Leap</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Power Blow</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pressure Points</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pressure Secrets</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Super-Spy)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>15</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>All members of the character&#8217;s organization below his Rank, as well as enemy agents of roughly equal Rank who are aware of his identity</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to rank for clearance and aid, but not for authority or pay.</notes>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Acting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Current Affairs</name>
-			<specialization compare="is">Politics</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Detect Lies</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Disguise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Escape</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fast-Talk</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Holdout</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Interrogation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Observation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pickpocket</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Search</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shadowing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sleight of Hand</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Stealth</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Tracking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Superior Equilibrioception)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Acrobats, skydivers, and commandos who slide down ropes.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to DX anywhere Perfect Balance would apply</notes>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Acrobatics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Aerobatics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Aquabatics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Body Sense</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Climbing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Free Fall</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Parachuting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Survivor)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Scouts, campers, and survivalists.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Scrounging to find simple equipment with offseting improvides equipment penalty.  Must be simple!</notes>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">First Aid</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Knot-Tying</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Naturalist</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Scrounging</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Survival</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Talker)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Investigators and anybody hiring you to investigate</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to resist verbal influence attempts</notes>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Detect Lies</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Diplomacy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fast-Talk</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Savoir-Faire</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Thanatologist)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Death-worshippers and sapient undead you don&#8217;t try to exorcize or banish</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to fright checks from undead and bodies</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Exorcism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is">Thanatology</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Occultism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Professional Skill</name>
-			<specialization compare="is">Mortician</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Religious Ritual</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Theology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Tough Guy)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Most police officers and detectives, bouncers, gangsters, and street thugs</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to resist Interrogation and Intimidation, and to Fright Checks resulting from encountering murder victims, bloody torture scenes, etc.</notes>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Fast-Talk</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Forced Entry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Intimidation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shadowing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Streetwise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Trivia Sponge)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Anybody who cares about trivia</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus anywhere Eidetic Memory gives a bonus</notes>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Area Knowledge</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Current Affairs</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Games</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hobby Skill</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Truth-Seeker)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Anyone who is Curious or harbors Delusions about conspiracies</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus in Contests against attempts to perpetrate a cover-up.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Detect Lies</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is">Conspiracy Theory</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is">Conspiracies</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Intelligence Analysis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Interrogation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Research</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Unseelie Talent)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:17</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Camouflage</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Disguise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Scrounging</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Stealth</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Survival Urban Survival</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Widget-Worker)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Those who benefit directly from your skills</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Success at an appropriate covered skill lets you scround equipment for another skill and eliminates level of the penalty for improvised equipment. Shift rolls by level to avoid harm from tampering with mundane mechanisms.</notes>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Armoury</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Forced Entry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Lockpicking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Scrounging</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Traps</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="is">Gnome</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Tattletale</name>
+		<name>Doesn&#8217;t trust banks</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
 		<reference>PU6:30</reference>
@@ -10919,70 +9566,101 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Taunting</name>
-		<type>Mental, Social</type>
+		<name>Distractible</name>
+		<type>Mental</type>
 		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
+		<reference>PU6:18</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Teamwork (@Group@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:8</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Technique Adaptation (@Technique@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:17</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Technique Mastery (@Technique@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:17</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Tests Positive for @Condition@</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:25</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Thin Skull</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:25</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Third Person</name>
+		<name>Distinctive Speech</name>
 		<type>Mental, Social</type>
 		<base_points>-1</base_points>
 		<reference>PU6:16</reference>
+		<notes>@Subject@</notes>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Timid</name>
+		<name>Distinctive Features</name>
+		<type>Physical, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:14</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Disposable Identity</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<reference>PU2:18</reference>
+		<notes>@Details@</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Disorganized</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:18</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dislike (@Subject@)</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:26</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dishonest Face</name>
+		<type>Physical, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:14</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Disciplined</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:18</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Disarming Smile</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<notes>Non-Verbal Diplomacy</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dirty Fighting</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Determined</name>
 		<type>Mental, Social</type>
 		<base_points>-1</base_points>
 		<reference>PU6:18</reference>
@@ -10991,187 +9669,186 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Tiny Hands</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:25</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Token (@Subject@)</name>
+		<name>Desirous</name>
 		<type>Mental, Social</type>
 		<base_points>-1</base_points>
-		<reference>PU6:16</reference>
+		<reference>PU6:18</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Tone-Deaf</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:25</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Trademark</name>
+		<name>Delusional Competence (@Skill@)</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
-		<reference>PU6:30</reference>
+		<reference>PU6:17</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Delusion</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:17</reference>
 		<notes>@Subject@</notes>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Trademark Move</name>
+		<name>Deep Sleeper</name>
 		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:8</reference>
-		<notes>@Description@</notes>
+		<reference>PU2:13</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Transporter (@Vehicle Skill@)</name>
+		<name>Decisive</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:17</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dead Weight</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dead Giveaway</name>
+		<type>Physical, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:13</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Damned</name>
+		<type>Supernatural</type>
+		<base_points>-1</base_points>
+		<reference>PU6:34</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Daily Ritual</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:28</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dabbler</name>
 		<type>Mental/Physical</type>
 		<base_points>1</base_points>
 		<reference>PU2:16</reference>
-		<notes>No rolls for some vehicle tasks.</notes>
+		<notes>@Up to 8 Skills@</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Cyclothymic</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:17</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Cutting Edge Training (@Skill@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:16</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Crossbow Finesse</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Cross-Trained (@Skill@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:16</reference>
 		<categories>
 			<category>Cinematic</category>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Trivial Destiny</name>
-		<type>Supernatural</type>
+		<name>Cross-Species Surrogacy (@Species@)</name>
+		<type>Physical, Exotic</type>
 		<base_points>1</base_points>
-		<reference>PU2:20</reference>
-		<notes>@Details@</notes>
+		<reference>PU2:10</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Trivial Destiny</name>
-		<type>Supernatural</type>
+		<name>Credulous</name>
+		<type>Mental, Social</type>
 		<base_points>-1</base_points>
-		<reference>PU6:34</reference>
-		<notes>@Subject@</notes>
+		<reference>PU6:18</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Trivial Reputation</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:33</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Trivial Reputation (@Description@)</name>
-		<type>Social</type>
+		<name>Covenant of Rest</name>
+		<type>Social, Supernatural</type>
 		<base_points>1</base_points>
+		<reference>PU2:19</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Courtesy Title (@Title@)</name>
+		<type>Social</type>
+		<levels>1</levels>
+		<points_per_level>1</points_per_level>
 		<reference>PU2:18</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Trivial Secret</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:33</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Twirl (@Weapon Skill@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Twitchy</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:25</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Unarmed Parry (@Weapon@)</name>
+		<name>Cotton Stomach</name>
 		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:8</reference>
+		<reference>PU2:5</reference>
 		<categories>
+			<category>Cinematic</category>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Unbelievable at @Ability@</name>
-		<type></type>
-		<base_points>-1</base_points>
-		<reference>PU6:21</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Uncongenial</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Unique Technique (@Technique@)</name>
-		<type></type>
-		<base_points>1</base_points>
-		<reference>PU2:21</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Unusual Posture (@Task and Posture@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:17</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Unusual Training (@Cinematic Technique@)</name>
-		<type></type>
-		<base_points>1</base_points>
-		<reference>PU2:21</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Unwelcome Accessory (@Subject@)</name>
-		<type>Physical, Exotic</type>
+		<name>Cosmetic Eyeglasses</name>
+		<type>Physical, Social</type>
 		<base_points>-1</base_points>
 		<reference>PU6:13</reference>
 		<categories>
@@ -11179,26 +9856,1213 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Variable Quirk</name>
-		<type></type>
+		<name>Cooperative</name>
+		<type>Mental, Social</type>
 		<base_points>-1</base_points>
-		<reference>PU6:21</reference>
+		<reference>PU6:18</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Convincing Nod</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<notes>Non-Verbal Fast-Talk</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Controllable Disadvantage (@Disadvantage@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:12</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Controllable Disadvantage (@Disadvantage@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Congenial</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:17</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Compulsion</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:27</reference>
 		<notes>@Subject@</notes>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Vehicle (@Type@)</name>
+		<name>Complicated</name>
 		<type>Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:32</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Compact Frame</name>
+		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:18</reference>
+		<reference>PU2:13</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Villain-Worshipper</name>
+		<name>Combat Vaulting (@Reach 2+ Polearm Skill@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Combat Hesitancy</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>College Incompetence (@Subject@)</name>
+		<type>Supernatural</type>
+		<base_points>-1</base_points>
+		<reference>PU6:34</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Collector (@Subject@)</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:27</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Cold Intolerance</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:25</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Code of Honor</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:9</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Clumsy Runner</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Cloaked</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Clinch (Karate)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Clinch (Brawling)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Clinch (Boxing)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Climbing Line</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:10</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Clean freak</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:30</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Classic Features (@Features@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:4</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Citizenship (@State@)</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<modifier version="1" enabled="no">
+			<name>Home</name>
+			<cost type="points">-1</cost>
+			<affects>total</affects>
+			<notes>You get one free citizenship.</notes>
+		</modifier>
+		<reference>PU2:17</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Chi Resistance (@Chi-based Effect@)</name>
+		<type>Supernatural</type>
+		<base_points>1</base_points>
+		<reference>PU2:19</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Checkered Past</name>
+		<type>Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:32</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Cheaper (@Gear@; @Percentage@%)</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<reference>PU2:8</reference>
+		<notes>@Reason@</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Chauvinistic</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:17</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Charm (@Spell@)</name>
+		<type>Supernatural</type>
+		<base_points>1</base_points>
+		<reference>PU2:19</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Carries backup weapons</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:30</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Carrier (@Disease@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Careful planner</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:30</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Careful</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:17</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Care (@Subject@)</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Can&#8217;t Read Music</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:31</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Cannot Float</name>
+		<type>Physical, Exotic</type>
+		<base_points>-1</base_points>
+		<reference>PU6:12</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Can Be Turned By True Faith</name>
+		<type>Supernatural</type>
+		<base_points>-1</base_points>
+		<reference>PU6:33</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Call of the Wild</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:12</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+		<prereq_list all="yes">
+			<advantage_prereq has="yes">
+				<name compare="is">Animal Empathy</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Burrower</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:10</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Bulky Frame</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Brotherhood (@Group@)</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<reference>PU2:17</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Broad-Minded</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:17</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Bowlegged</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Born Goon</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:18</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Biting Mastery</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Better (@Gear@)</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<reference>PU2:8</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Base</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<reference>PU2:17</reference>
+		<notes>@Description@</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Bad Posture</name>
+		<type>Physical, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:13</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Background Knowledge (@Background@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:16</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Autotrance</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:12</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Attentive</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:17</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Atheist</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:8</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Armorer&#8217;s Gift (@Weapon Skill@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Armor Familiarity (@Combat Skill@)</name>
+		<type>Physical</type>
+		<levels>1</levels>
+		<points_per_level>1</points_per_level>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Anti-Talent (Unsubtle)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>-5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Penalty</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Sneaky people and anyone who catches you in the act</notes>
+		</modifier>
+		<modifier version="1">
+			<name>Additional Drawback</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to others' rolls to notice or remember you</notes>
+		</modifier>
+		<reference>PU3:21</reference>
+		<categories>
+			<category>Disadvantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Camouflage</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Disguise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Holdout</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shadowing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Smuggling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Stealth</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Anti-Talent (Noncombatant)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>-15</points_per_level>
+		<modifier version="1">
+			<name>Reaction Penalty</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Anyone who would react poorly to Cowardice</notes>
+		</modifier>
+		<reference>PU3:21</reference>
+		<notes>Penalty to all combat rolls except active defenses, which are based on reduced skills instead</notes>
+		<categories>
+			<category>Disadvantage</category>
+			<category>Talent</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Anti-Talent (Misfit)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>-15</points_per_level>
+		<modifier version="1">
+			<name>Reaction Penalty</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Anyone you try to impress</notes>
+		</modifier>
+		<modifier version="1">
+			<name>Additional Drawback</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Penalty to resist Influence skills and manipulation</notes>
+		</modifier>
+		<reference>PU3:20</reference>
+		<categories>
+			<category>Disadvantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Acting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Administration</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Carousing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Connoisseur</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Detect Lies</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Diplomacy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fast-Talk</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Gambling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Gesture</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Intimidation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Leadership</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Merchant</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Politics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Propaganda</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Public Speaking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Savoir-Faire</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sex Appeal</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Teaching</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Anti-Talent (Mind like a Sieve)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>-5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Penalty</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Anybody who values knowledge</notes>
+		</modifier>
+		<modifier version="1">
+			<name>Additional Drawback</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Penalty anywhere Eidetic Memory would give a bonus</notes>
+		</modifier>
+		<reference>PU3:20</reference>
+		<categories>
+			<category>Disadvantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Area Knowledge</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Connoisseur</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Current Affairs</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hobby Skill</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Anti-Talent (Couch Potato)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>-10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Penalty</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Athletes, fitness nuts, and anyone with higher HT than you</notes>
+		</modifier>
+		<modifier version="1">
+			<name>Additional Drawback</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Penalty to recover from injuries due to physical feats</notes>
+		</modifier>
+		<reference>PU3:20</reference>
+		<categories>
+			<category>Disadvantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Acrobatics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Bicycling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Climbing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hiking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Jumping</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Lifting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Running</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Skating</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Skiing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sports</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Swimming</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Throwing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Anti-Talent (Animal Foe)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>-5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Penalty</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>All animals, all the time</notes>
+		</modifier>
+		<modifier version="1">
+			<name>Additional Drawback</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Penalty to evaluate animals</notes>
+		</modifier>
+		<reference>PU3:20</reference>
+		<categories>
+			<category>Disadvantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Animal Handling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Falconry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Packing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Riding</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Teamster</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Veterinary</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Anti-Talent (@Small@)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>-5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Penalty</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>@Reaction Penalty@</notes>
+		</modifier>
+		<modifier version="1">
+			<name>Additional Drawback</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>@Additional Drawback@</notes>
+		</modifier>
+		<reference>PU3:19</reference>
+		<categories>
+			<category>Disadvantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">@skill1@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill2@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill3@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill4@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill5@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill6@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Anti-Talent (@Medium@)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>-10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Penalty</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>@Reaction Penalty@</notes>
+		</modifier>
+		<modifier version="1">
+			<name>Additional Drawback</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>@Additional Drawback@</notes>
+		</modifier>
+		<reference>PU3:19</reference>
+		<categories>
+			<category>Disadvantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">@skill01@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill02@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill03@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill04@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill05@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill06@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill07@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill08@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill09@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill10@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill11@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill12@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Anti-Talent (@Large@)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>-15</points_per_level>
+		<modifier version="1">
+			<name>Reaction Penalty</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>@Reaction Penalty@</notes>
+		</modifier>
+		<modifier version="1">
+			<name>Additional Drawback</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>@Additional Drawback@</notes>
+		</modifier>
+		<reference>PU3:19</reference>
+		<categories>
+			<category>Disadvantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">@skill01@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill02@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill03@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill04@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill05@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill06@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill07@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill08@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill09@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill10@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill11@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill12@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill13@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill14@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill15@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill16@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill17@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Amoral</name>
 		<type>Mental, Social</type>
 		<base_points>-1</base_points>
 		<reference>PU6:15</reference>
@@ -11207,38 +11071,162 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Vow (@Subject@)</name>
-		<type>Mental</type>
+		<name>Allergy (@Subject@)</name>
+		<type>Physical</type>
 		<base_points>-1</base_points>
-		<reference>PU6:9</reference>
+		<reference>PU6:22</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Weapon Adaptation (@Weapon@ to @Weapon@)</name>
+		<name>Alcohol Tolerance</name>
 		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:8</reference>
+		<reference>PU2:13</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Weapon Bond (@Specific Weapon@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:9</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Willful Ignorance</name>
+		<name>Alcohol Intolerance</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
-		<reference>PU6:9</reference>
-		<notes>@Subject@</notes>
+		<reference>PU6:29</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Akimbo (@Weapon Skill@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Air Jet</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:10</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Affected by Magnetism</name>
+		<type>Physical, Exotic</type>
+		<base_points>-1</base_points>
+		<reference>PU6:12</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Admiration</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:25</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Acrobatic Feints</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Aches and Pains</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Accessory (@Accessory@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:10</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Accent (@Language@; @Region@)</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+		<prereq_list all="yes">
+			<advantage_prereq has="yes">
+				<name compare="is">Language: @Language@</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Accent (@Language@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:12</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Acceleration Weakness</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:24</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Acceleration Tolerance</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>@Skill@ based on @Stat@</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>@Racial@ Gifts</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:12</reference>
+		<notes>May purchase @Traits@</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>@Missing Disadvantage@</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>

--- a/Library/Power Ups/Power Ups Advantages.adq
+++ b/Library/Power Ups/Power Ups Advantages.adq
@@ -1,44 +1,7 @@
 <?xml version="1.0" encoding="US-ASCII" ?>
 <advantage_list id="b8e36f7e-6c5f-444e-b5d3-2947516b2dff" version="1">
 	<advantage version="3">
-		<name>Willful Ignorance</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:9</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Weapon Bond (@Specific Weapon@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:9</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Weapon Adaptation (@Weapon@ to @Weapon@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:8</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Vow (@Subject@)</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:9</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Villain-Worshipper</name>
+		<name>@Missing Disadvantage@</name>
 		<type>Mental, Social</type>
 		<base_points>-1</base_points>
 		<reference>PU6:15</reference>
@@ -47,27 +10,930 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Vehicle (@Type@)</name>
-		<type>Social</type>
+		<name>@Racial@ Gifts</name>
+		<type>Physical, Exotic</type>
 		<base_points>1</base_points>
-		<reference>PU2:18</reference>
+		<reference>PU2:12</reference>
+		<notes>May purchase @Traits@</notes>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Variable Quirk</name>
-		<type></type>
+		<name>@Skill@ based on @Stat@</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Acceleration Tolerance</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Acceleration Weakness</name>
+		<type>Physical</type>
 		<base_points>-1</base_points>
-		<reference>PU6:21</reference>
-		<notes>@Subject@</notes>
+		<reference>PU6:24</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Unwelcome Accessory (@Subject@)</name>
+		<name>Accent (@Language@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:12</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Accent (@Language@; @Region@)</name>
 		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+		<prereq_list all="yes">
+			<advantage_prereq has="yes">
+				<name compare="is">Language: @Language@</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Accessory (@Accessory@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:10</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Aches and Pains</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Acrobatic Feints</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Admiration</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:25</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Affected by Magnetism</name>
+		<type>Physical, Exotic</type>
+		<base_points>-1</base_points>
+		<reference>PU6:12</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Air Jet</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:10</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Akimbo (@Weapon Skill@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Alcohol Intolerance</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:29</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Alcohol Tolerance</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Allergy (@Subject@)</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Amoral</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Anti-Talent (@Large@)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>-15</points_per_level>
+		<modifier version="1">
+			<name>Reaction Penalty</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>@Reaction Penalty@</notes>
+		</modifier>
+		<modifier version="1">
+			<name>Additional Drawback</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>@Additional Drawback@</notes>
+		</modifier>
+		<reference>PU3:19</reference>
+		<categories>
+			<category>Disadvantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">@skill01@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill02@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill03@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill04@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill05@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill06@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill07@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill08@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill09@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill10@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill11@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill12@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill13@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill14@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill15@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill16@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill17@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Anti-Talent (@Medium@)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>-10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Penalty</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>@Reaction Penalty@</notes>
+		</modifier>
+		<modifier version="1">
+			<name>Additional Drawback</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>@Additional Drawback@</notes>
+		</modifier>
+		<reference>PU3:19</reference>
+		<categories>
+			<category>Disadvantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">@skill01@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill02@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill03@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill04@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill05@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill06@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill07@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill08@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill09@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill10@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill11@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill12@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Anti-Talent (@Small@)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>-5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Penalty</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>@Reaction Penalty@</notes>
+		</modifier>
+		<modifier version="1">
+			<name>Additional Drawback</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>@Additional Drawback@</notes>
+		</modifier>
+		<reference>PU3:19</reference>
+		<categories>
+			<category>Disadvantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">@skill1@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill2@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill3@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill4@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill5@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">@skill6@</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Anti-Talent (Animal Foe)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>-5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Penalty</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>All animals, all the time</notes>
+		</modifier>
+		<modifier version="1">
+			<name>Additional Drawback</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Penalty to evaluate animals</notes>
+		</modifier>
+		<reference>PU3:20</reference>
+		<categories>
+			<category>Disadvantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Animal Handling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Falconry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Packing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Riding</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Teamster</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Veterinary</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Anti-Talent (Couch Potato)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>-10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Penalty</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Athletes, fitness nuts, and anyone with higher HT than you</notes>
+		</modifier>
+		<modifier version="1">
+			<name>Additional Drawback</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Penalty to recover from injuries due to physical feats</notes>
+		</modifier>
+		<reference>PU3:20</reference>
+		<categories>
+			<category>Disadvantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Acrobatics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Bicycling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Climbing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hiking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Jumping</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Lifting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Running</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Skating</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Skiing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sports</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Swimming</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Throwing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Anti-Talent (Mind like a Sieve)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>-5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Penalty</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Anybody who values knowledge</notes>
+		</modifier>
+		<modifier version="1">
+			<name>Additional Drawback</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Penalty anywhere Eidetic Memory would give a bonus</notes>
+		</modifier>
+		<reference>PU3:20</reference>
+		<categories>
+			<category>Disadvantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Area Knowledge</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Connoisseur</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Current Affairs</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hobby Skill</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Anti-Talent (Misfit)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>-15</points_per_level>
+		<modifier version="1">
+			<name>Reaction Penalty</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Anyone you try to impress</notes>
+		</modifier>
+		<modifier version="1">
+			<name>Additional Drawback</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Penalty to resist Influence skills and manipulation</notes>
+		</modifier>
+		<reference>PU3:20</reference>
+		<categories>
+			<category>Disadvantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Acting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Administration</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Carousing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Connoisseur</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Detect Lies</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Diplomacy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fast-Talk</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Gambling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Gesture</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Intimidation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Leadership</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Merchant</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Politics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Propaganda</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Public Speaking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Savoir-Faire</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sex Appeal</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Teaching</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Anti-Talent (Noncombatant)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>-15</points_per_level>
+		<modifier version="1">
+			<name>Reaction Penalty</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Anyone who would react poorly to Cowardice</notes>
+		</modifier>
+		<reference>PU3:21</reference>
+		<notes>Penalty to all combat rolls except active defenses, which are based on reduced skills instead</notes>
+		<categories>
+			<category>Disadvantage</category>
+			<category>Talent</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Anti-Talent (Unsubtle)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>-5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Penalty</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Sneaky people and anyone who catches you in the act</notes>
+		</modifier>
+		<modifier version="1">
+			<name>Additional Drawback</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to others' rolls to notice or remember you</notes>
+		</modifier>
+		<reference>PU3:21</reference>
+		<categories>
+			<category>Disadvantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Camouflage</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Disguise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Holdout</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shadowing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Smuggling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Stealth</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">-1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Armor Familiarity (@Combat Skill@)</name>
+		<type>Physical</type>
+		<levels>1</levels>
+		<points_per_level>1</points_per_level>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Armorer&#8217;s Gift (@Weapon Skill@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Atheist</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:8</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Attentive</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:17</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Autotrance</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:12</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Background Knowledge (@Background@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:16</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Bad Posture</name>
+		<type>Physical, Social</type>
 		<base_points>-1</base_points>
 		<reference>PU6:13</reference>
 		<categories>
@@ -75,186 +941,35 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Unusual Training (@Cinematic Technique@)</name>
-		<type></type>
-		<base_points>1</base_points>
-		<reference>PU2:21</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Unusual Posture (@Task and Posture@)</name>
-		<type>Mental</type>
+		<name>Base</name>
+		<type>Social</type>
 		<base_points>1</base_points>
 		<reference>PU2:17</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Unique Technique (@Technique@)</name>
-		<type></type>
-		<base_points>1</base_points>
-		<reference>PU2:21</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Uncongenial</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Unbelievable at @Ability@</name>
-		<type></type>
-		<base_points>-1</base_points>
-		<reference>PU6:21</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Unarmed Parry (@Weapon@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:8</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Twitchy</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:25</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Twirl (@Weapon Skill@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Trivial Secret</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:33</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Trivial Reputation (@Description@)</name>
-		<type>Social</type>
-		<base_points>1</base_points>
-		<reference>PU2:18</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Trivial Reputation</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:33</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Trivial Destiny</name>
-		<type>Supernatural</type>
-		<base_points>-1</base_points>
-		<reference>PU6:34</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Trivial Destiny</name>
-		<type>Supernatural</type>
-		<base_points>1</base_points>
-		<reference>PU2:20</reference>
-		<notes>@Details@</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Transporter (@Vehicle Skill@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:16</reference>
-		<notes>No rolls for some vehicle tasks.</notes>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Trademark Move</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:8</reference>
 		<notes>@Description@</notes>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Trademark</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:30</reference>
-		<notes>@Subject@</notes>
+		<name>Better (@Gear@)</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<reference>PU2:8</reference>
 		<categories>
-			<category>Quirk</category>
+			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Tone-Deaf</name>
+		<name>Biting Mastery</name>
 		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:25</reference>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
 		<categories>
-			<category>Quirk</category>
+			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Token (@Subject@)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:16</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Tiny Hands</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:25</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Timid</name>
+		<name>Born Goon</name>
 		<type>Mental, Social</type>
 		<base_points>-1</base_points>
 		<reference>PU6:18</reference>
@@ -263,35 +978,26 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Third Person</name>
+		<name>Bowlegged</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Broad-Minded</name>
 		<type>Mental, Social</type>
 		<base_points>-1</base_points>
-		<reference>PU6:16</reference>
+		<reference>PU6:17</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Thin Skull</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:25</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Tests Positive for @Condition@</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:25</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Technique Mastery (@Technique@)</name>
-		<type>Mental/Physical</type>
+		<name>Brotherhood (@Group@)</name>
+		<type>Social</type>
 		<base_points>1</base_points>
 		<reference>PU2:17</reference>
 		<categories>
@@ -299,6176 +1005,59 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Technique Adaptation (@Technique@)</name>
-		<type>Mental/Physical</type>
+		<name>Bulky Frame</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Burrower</name>
+		<type>Physical, Exotic</type>
 		<base_points>1</base_points>
-		<reference>PU2:17</reference>
+		<reference>PU2:10</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Teamwork (@Group@)</name>
-		<type>Physical</type>
+		<name>Call of the Wild</name>
+		<type>Mental</type>
 		<base_points>1</base_points>
-		<reference>PU2:8</reference>
+		<reference>PU2:12</reference>
 		<categories>
+			<category>Cinematic</category>
 			<category>Perk</category>
 		</categories>
+		<prereq_list all="yes">
+			<advantage_prereq has="yes">
+				<name compare="is">Animal Empathy</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
 	</advantage>
 	<advantage version="3">
-		<name>Taunting</name>
-		<type>Mental, Social</type>
+		<name>Can Be Turned By True Faith</name>
+		<type>Supernatural</type>
 		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
+		<reference>PU6:33</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Tattletale</name>
-		<type>Mental</type>
+		<name>Cannot Float</name>
+		<type>Physical, Exotic</type>
 		<base_points>-1</base_points>
-		<reference>PU6:30</reference>
+		<reference>PU6:12</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Talent (Widget-Worker)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Those who benefit directly from your skills</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Success at an appropriate covered skill lets you scround equipment for another skill and eliminates level of the penalty for improvised equipment. Shift rolls by level to avoid harm from tampering with mundane mechanisms.</notes>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Armoury</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Forced Entry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Lockpicking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Scrounging</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Traps</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="is">Gnome</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Unseelie Talent)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:17</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Camouflage</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Disguise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Scrounging</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Stealth</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Survival Urban Survival</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Truth-Seeker)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Anyone who is Curious or harbors Delusions about conspiracies</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus in Contests against attempts to perpetrate a cover-up.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Detect Lies</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is">Conspiracy Theory</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is">Conspiracies</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Intelligence Analysis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Interrogation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Research</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Trivia Sponge)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Anybody who cares about trivia</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus anywhere Eidetic Memory gives a bonus</notes>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Area Knowledge</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Current Affairs</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Games</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hobby Skill</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Tough Guy)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Most police officers and detectives, bouncers, gangsters, and street thugs</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to resist Interrogation and Intimidation, and to Fright Checks resulting from encountering murder victims, bloody torture scenes, etc.</notes>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Fast-Talk</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Forced Entry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Intimidation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shadowing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Streetwise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Thanatologist)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Death-worshippers and sapient undead you don&#8217;t try to exorcize or banish</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to fright checks from undead and bodies</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Exorcism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is">Thanatology</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Occultism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Professional Skill</name>
-			<specialization compare="is">Mortician</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Religious Ritual</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Theology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Talker)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Investigators and anybody hiring you to investigate</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to resist verbal influence attempts</notes>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Detect Lies</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Diplomacy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fast-Talk</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Savoir-Faire</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Survivor)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Scouts, campers, and survivalists.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Scrounging to find simple equipment with offseting improvides equipment penalty.  Must be simple!</notes>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">First Aid</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Knot-Tying</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Naturalist</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Scrounging</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Survival</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Superior Equilibrioception)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Acrobats, skydivers, and commandos who slide down ropes.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to DX anywhere Perfect Balance would apply</notes>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Acrobatics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Aerobatics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Aquabatics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Body Sense</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Climbing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Free Fall</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Parachuting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Super-Spy)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>15</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>All members of the character&#8217;s organization below his Rank, as well as enemy agents of roughly equal Rank who are aware of his identity</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to rank for clearance and aid, but not for authority or pay.</notes>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Acting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Current Affairs</name>
-			<specialization compare="is">Politics</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Detect Lies</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Disguise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Escape</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fast-Talk</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Holdout</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Interrogation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Observation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pickpocket</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Search</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shadowing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sleight of Hand</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Stealth</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Tracking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Strong Chi)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Other martial artists, especially potential masters or students.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>+1/level on rolls to be heard (compare Penetrating Voice, p. B101), and to Intimidation attempts made after using one of the affected skills.</notes>
-		</modifier>
-		<reference>PU3:8</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Breaking Blow</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Flying Leap</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Power Blow</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pressure Points</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pressure Secrets</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Street-Smart)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Shady characters in town.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to notice inner city dangers and scams and to Tracking in built up areas.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Merchant</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Panhandling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Scrounging</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shadowing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Streetwise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Urban Survival</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="no">
-				<name compare="is">Talent (Street Smarts)</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Street Smarts)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Other street operators</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to notice inner city dangers and scams and to Tracking in built up areas.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:16</reference>
-		<notes>Familiarity with a new city for city specific skills requires 6-level months</notes>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Area Knowledge</name>
-			<specialization compare="is">@City@</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Current Affairs</name>
-			<specialization compare="is">@City@</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Law</name>
-			<specialization compare="is">@City@</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Merchant</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Panhandling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Scrounging</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shadowing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Streetwise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Urban Survival</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="no">
-				<name compare="is">Talent (Street-Smart)</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Strangler)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to Per to notice people sneaking within arms reach of you</notes>
-		</modifier>
-		<reference>PU3:15</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Brawling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Stealth</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Tracking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Wrestling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="is">Throttler</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Stalker)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Hunters, trackers, etc.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>+1/level to Per rolls to keep track of a specific quarry you&#8217;ve already spotted using other skills.</notes>
-		</modifier>
-		<reference>PU3:15</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Camouflage</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hiking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Navigation (Land)</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Stealth</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Tracking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Spirit-Talker)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Spirits</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:15</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Exorcism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fortune-Telling</name>
-			<specialization compare="is anything">Augury</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fortune-Telling</name>
-			<specialization compare="is anything">Dream Interpretation</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is anything">Spirits</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Meditation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Occultism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Theology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Social Scientist)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Social and political thinkers, theorists, and activists</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to Acting, Disguise, and Fast-Talk to pass as a member of another political/religious group.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:15</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Anthropology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Archaeology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Criminology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Economics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is">Political Science</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Geography</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">History</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Philosophy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sociology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Theology</name>
-			<specialization compare="is">Comparative</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Smooth Operator)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>15</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Con artists, politicians, salesmen, etc. &#8211; but only if you aren&#8217;t trying to manipulate them.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to resist covered skills</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-2</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:15</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Acting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Carousing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Detect Lies</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Diplomacy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fast-Talk</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Intimidation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Leadership</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Panhandling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Politics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Public Speaking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Savoir-Faire</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sex Appeal</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Streetwise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Seafarer)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Sailors, pirates, and aquatic races sympathetic to sea travel</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to resist seasicknes and reduce unfamiliarity penalties for system on an appropriate boat or ship. Bonus to Carousing and Streetwise in port towns.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:14</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Boating</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fishing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Knot-Tying</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Meteorology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Weather Sense</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Navigation</name>
-			<specialization compare="is anything">Sea</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Seamanship</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Survival</name>
-			<specialization compare="is anything">Island/Beach</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Swimming</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Thrown Weapon</name>
-			<specialization compare="is anything">Harpoon</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="no">
-				<name compare="is">Talent (Born Sailor)</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-			<advantage_prereq has="no">
-				<name compare="is">Talent (Mariner)</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Sage)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Scholars, students, and people who consult you</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to IQ defaults to non-covered skills for general knowledge only</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">2</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:15</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Archaeology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Geography</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Heraldry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">History</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Law</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Literature</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Occultism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Philosophy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Research</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Theology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Psientist)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Psis</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to self control rolls after a successful Meditation, Mental Strength, or Mind Block</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:15</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Hypnotism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Meditation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mental Strength</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mind Block</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is">Psionics</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is">Psionics</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Pop Culture Maven)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Obsessive pop culture devotees</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to Influence or Carousing to demonstrate you are "cool".</notes>
-		</modifier>
-		<reference>PU3:14</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Connoisseur</name>
-			<specialization compare="is anything">Virtual Reality Arts</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Current Affairs</name>
-			<specialization compare="is anything">People</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Current Affairs</name>
-			<specialization compare="is anything">Popular Culture</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Current Affairs</name>
-			<specialization compare="is anything">Sports</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is anything">Memetics</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Poet)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Readers and listeners of your work; literati.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>+1/level to the first Influence roll (p. B359) of any kind made on an audience member (or several of them as a group) after a successful performance.</notes>
-		</modifier>
-		<reference>PU3:14</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Connoisseur (Literature)</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Literature</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Poetry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Public Speaking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Writing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Pickaxe Penchant)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Miners</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to will for Extra Effort when digging, HT on failure at such, and all rolls to avoid disasters in mines</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">0</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:14</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Axe/Mace</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Forced Entry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Prospecting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Thrown Weapon</name>
-			<specialization compare="is anything">Axe/Mace</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Two-Handed Axe/Mace</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="is">Dwarf</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Parapsychologist)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Psis and beleivers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to resist powers that have been examined with covered skills</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:14</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Electronics Operation</name>
-			<specialization compare="is anything">Medical</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Electronics Operation</name>
-			<specialization compare="is anything">Psychotronics</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Electronics Operation</name>
-			<specialization compare="is anything">Scientific</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is anything">Psionics</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hypnotism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Occultism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Physics</name>
-			<specialization compare="is anything">Paraphysics</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Outdoorsman)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Explorers and nature lovers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to HT rolls to avoid harm from failure of covered skills</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-3</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:14</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Camouflage</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fishing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mimicry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Naturalist</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Navigation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Survival</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Tracking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Occultist)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Students of the arcane, gullible college students, monster-hunters.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Benefit</name>
-			<cost type="points">2</cost>
-			<affects>levels only</affects>
-			<notes>+1/level to Fright Checks caused by supernatural beings and effects, and by reading sanity-destroying tomes (because you know what to expect).</notes>
-		</modifier>
-		<reference>PU3:14</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Alchemy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Anthropology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Archaeology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Exorcism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">History</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Linguistics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Literature</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Occultism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Research</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Ritual Magic</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Thaumatology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Ninja Talent)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1" enabled="no">
-			<name>Power Talent</name>
-			<reference>DF12:4</reference>
-			<cost type="points">5</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:7</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Blind Fighting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hypnotism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Invisibility Art</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Light Walk</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mental Strength</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Natural Scientist)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Scientists and those impressed by "smart people"</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Reduce TL and familiarity penalties for gear examined for an hour with a covered skill</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:13</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Astronomy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Chemistry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is anything">Hydrology</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is anything">Natural Philosophy</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Geology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mathematics</name>
-			<specialization compare="is anything">Applied</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mathematics</name>
-			<specialization compare="is anything">Statistics</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mathematics</name>
-			<specialization compare="is anything">Surveying</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Metallurgy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Meteorology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Paleontology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Physics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pysiology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Natural Diver)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Expert divers and aquatic beings</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to HT for breath holding time and resisting the Bends, Nitrogen Narcosis, etc.</notes>
-		</modifier>
-		<reference>PU3:13</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Aquabatics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Diving Suit</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Scuba</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is anything">Submarine</name>
-			<specialization compare="is">Free-Flooding Sub</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Swimming</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Natural Copper)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Police and PIs</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to unskilled Per rolls to notice clues, and to all rolls to use Intuition</notes>
-		</modifier>
-		<reference>PU3:13</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Body Language</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Criminology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Detect Lies</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Intelligence Analysis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Interrogation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Observation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Savoir-Faire</name>
-			<specialization compare="is anything">Police</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Search</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shadowing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Streetwise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Natural Athlete)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Sports fans, coaches, and recruiters</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to HT to recover from injuries resulting from failures with covered skills</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:13</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Bicycling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Breath Control</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hiking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Jumping</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Lifting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Running</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Skating</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Skiing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sports</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Swimming</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Throwing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Musical Ability)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Audiences and Critics</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to first influence roll made against one or more audience members after a successful performance.</notes>
-		</modifier>
-		<reference>PU3:13</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Group Performance</name>
-			<specialization compare="is">Conducting</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Musical Composition</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Musical Influence</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Musical Instrument</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Singing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Mr. Smash)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to intimidate when victim at your mercy and you are threatening with a covered weapon</notes>
-		</modifier>
-		<reference>PU3:13</reference>
-		<notes>Covers Forced-Entry, but only when used with a swung Two Handed weapon.</notes>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Polearm</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Two-Handed Axe/Mace</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Two-Handed Flail</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Two-Handed Sword</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Mesmerist)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>The foolish and weak-minded.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>+1/level to resist any of the affected skills.</notes>
-		</modifier>
-		<reference>PU3:12</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Autohypnosis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Brainwashing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Captivate</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Gesture</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hypnotism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Intimidation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Musical Influence</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Persuade</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Suggest</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sway Emotions</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Memetics)</name>
-		<type>Mental, Exotic</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Other memeticists who see you working</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to resist Brainwashing, Fast-Talk, and Propaganda</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">2</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:12</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Brainwashing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Diplomacy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is anything">Memetics</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fast-Talk</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Interrogation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Leadership</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Merchant</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Politics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Propaganda</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sociology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Teaching</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Mathematical Ability)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Engineers and scientists</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to resist deception involving numbers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-2</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:12</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Accounting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Astronomy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Cryptography</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Engineer</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Finance</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Market Analysis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mathematics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Physics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Master Builder)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Workers on projects, prospective employers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to avoid common workplace hazards, even if used as traps</notes>
-		</modifier>
-		<reference>PU3:11</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Architecture</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Carpentry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Engineer</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Forced Entry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Masonry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Mariner)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Seafarers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to resist seasicknes and reduce unfamiliarity penalties for system on an appropriate boat or ship</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-3</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:13</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Boating</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Freight Handling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Knot-Tying</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Meteorology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Navigation</name>
-			<specialization compare="is">Sea</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Seamanship</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shiphandling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Weather Sense</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="no">
-				<name compare="is">Talent (Born Sailor)</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Jack of All Trades)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<reference>PU3:11</reference>
-		<notes>Bonus to all defaults from attributes</notes>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Intuitive Statesman)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Political Parties seeking candidates, those who put you in power</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to influence rolls to be chosen over another for a job or posting, or to cover up a failure with a covered skill.</notes>
-		</modifier>
-		<reference>PU3:11</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Administration</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Current Affairs</name>
-			<specialization compare="is">Headline News</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Current Affairs</name>
-			<specialization compare="is">People</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Current Affairs</name>
-			<specialization compare="is">Politics</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Diplomacy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Economics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Law</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Leadership</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Politics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Propaganda</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Public Speaking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Intuitive Admiral (Space))</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Anyone you serve with or command</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to initiative roll if leader</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-2</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:12</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is">Military Science</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">History</name>
-			<specialization compare="ends with">Military</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Intelligence Analysis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Leadership</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Savoir-Faire</name>
-			<specialization compare="is">Military</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shiphandling</name>
-			<specialization compare="is">Spaceship</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shiphandling</name>
-			<specialization compare="is">Starship</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Spacer</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Strategy</name>
-			<specialization compare="is">Space</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Intuitive Admiral (Sea))</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Anyone you serve with or command</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to initiative roll if leader</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-2</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:12</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is">Military Science</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">History</name>
-			<specialization compare="ends with">Military</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Intelligence Analysis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Leadership</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Savoir-Faire</name>
-			<specialization compare="is">Military</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shiphandling</name>
-			<specialization compare="is">Ship</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shiphandling</name>
-			<specialization compare="is">Submarine</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Seamanship</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Strategy</name>
-			<specialization compare="is">Sea</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Submariner</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Inner Balance)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>15</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Pacifists, Ascetics, Soft stylists</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to resist mundane disease</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:7</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Autohypnosis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Blind Fighting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Body Control</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Body Language</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Body Sense</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Breath Control</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Dreaming</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Immovable Stance</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Light Walk</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Lizard Climb</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Meditation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mental Strength</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mind Block</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sensitivity</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Impersonator)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus in contests against covered skills</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:11</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Acting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Body Language</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Disguise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mimicry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Savoir-Faire</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Streetwise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Hot Pilot)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Other Pilots</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Reduce penalties for unfamiliar systems of vehicles you have Piloting skill for</notes>
-		</modifier>
-		<reference>PU3:11</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Gunner</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Navigation</name>
-			<specialization compare="is">Air</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Navigation</name>
-			<specialization compare="is">Space</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Piloting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Healer)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Patients</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to HT rolls for a specific patient and condition if treated full time.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:11</reference>
-		<notes>Modern</notes>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Diagnosis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Esoteric Medicine</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">First Aid</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pharmacy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Physician</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Physiology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Surgery</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Veterinary</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Electronics Operation</name>
-			<specialization compare="is">Medical</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is">Epidemiology</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="no">
-				<name compare="is">Talent (Healer)</name>
-				<notes compare="does not contain">Modern</notes>
-				<level compare="at least">1</level>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Healer)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Patients</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to HT rolls for a specific patient and condition if treated full time.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:11</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Diagnosis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Esoteric Medicine</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">First Aid</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pharmacy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Physician</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Physiology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Surgery</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Veterinary</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="no">
-				<name compare="is">Talent (Healer)</name>
-				<notes compare="contains">Modern</notes>
-				<level compare="at least">1</level>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Green Thumb)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Gardeners and Sentient plants</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to rolls to survive made by plants in your care.</notes>
-		</modifier>
-		<reference>PU3:11</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Biology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Farming</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Gardening</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Herb Lore</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Naturalist</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Goodwife)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Beneficiaries, prospective spouses, other housewives</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to defaults made in your own home to repair, maintain, and protect it.</notes>
-		</modifier>
-		<reference>PU3:10</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Cooking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Diagnosis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Gardening</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Housekeeping</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sewing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Gifted Artist)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Buyers and Critics</notes>
-		</modifier>
-		<reference>PU3:10</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Artist</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Jeweler</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Leatherworking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Photography</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sewing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Forest Guardian)</name>
-		<type>Mental, Exotic, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Druids, Faeries, and bunnies</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to notice intruders, etc in woodland where you've lived from 6-level months.</notes>
-		</modifier>
-		<reference>PU3:10</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Bow</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Camouflage</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fast-Draw</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Stealth</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Survival</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="ends with">Elf</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Forensics Whiz Kid)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Crime-lab employers and detectives</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to Per to spot clues when no skill applies</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:16</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Chemistry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Criminology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Diagnosis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Forensics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Research</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Forceful Chi)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>15</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Honourable opponents, Hard stylists, Lovers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to be heard or to Intimidation after using a covered skill</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:7</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Breaking Blow</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Erotic Art</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Flying Leap</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hypnotic Hands</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hypnotism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Invisibility Art</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Kiai</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Power Blow</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Precognitive Parry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pressure Points</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pressure Secrets</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Push</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Throwing Art</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Zen Archery</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Explorer)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Fellow explorers and backers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Reduce distance and area class penalties for all skills</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">0</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:10</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Area Knowledge</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Cartography</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Geography</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mathematics</name>
-			<specialization compare="is">Surveying</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Navigation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Empath)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>IQ-4+level roll as for Empathy</notes>
-		</modifier>
-		<reference>PU3:10</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Body Language</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Detect Lies</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Diplomacy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fortune-Telling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Elder Gift)</name>
-		<type>Mental, Exotic, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Elder Things</notes>
-		</modifier>
-		<reference>PU3:6</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Alchemy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Occultism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Thaumatology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Dungeon Artificer)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Potential Buyers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Roll appropriate skill to scrounge equipment for other covered skills and apply level against the penalty.  Shift rolls to avoid ill effects from mysterious artifacts by level in either direction.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:10</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Alchemy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Armoury</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Engineer</name>
-			<specialization compare="is">Gadgets</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fast-Draw</name>
-			<specialization compare="is">Gadgets</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Scrounging</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Traps</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Driver's Reflexes)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Passengers; gamblers betting on you at the Grand Prix.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>+1/level on Per rolls to notice dangers in the path of your ride: running children, oncoming vehicles, landmines...</notes>
-		</modifier>
-		<reference>PU3:10</reference>
-		<categories>
-			<category>Advantage</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Boating</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Driving</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Piloting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Submarine</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Devotion)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Coreligionists and sympathizers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to will to resist "evil influences"</notes>
-		</modifier>
-		<reference>PU3:9</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Autohypnosis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Exorcism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Meditation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Religious Ritual</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Cyberneticist)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Other computer professionals, AI systems, and robots</notes>
-		</modifier>
-		<reference>PU3:9</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Computer Hacking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Computer Operation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Computer Programming</name>
-			<specialization compare="is"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Computer Programming</name>
-			<specialization compare="is">AI</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Electronics Repair</name>
-			<specialization compare="is">Computers</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Cunning Folk)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Local peasantry, clients, and acolytes.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Benefit</name>
-			<cost type="points">-2</cost>
-			<affects>levels only</affects>
-			<notes>A roll at IQ-4, +1/level of Cunning Folk, to notice anything odd &#8211; curses, blights, faeries in the basement, etc. &#8211; that happens to animals, crops, or people in an area where you&#8217;ve lived for at least (6 - Cunning Folk level) months.</notes>
-		</modifier>
-		<reference>PU3:9</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Animal Handling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fortune-Telling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Herb Lore</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Naturalist</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Occultism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Poisons</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Veterinary</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Weather Sense</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Cultural Chameleon)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Other cultures in their lands</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:9</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Anthropology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Diplomacy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Gesture</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Linguistics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sociology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Craftiness)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus: None</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:9</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Camouflage</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Disguise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Holdout</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shadowing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Stealth</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Acting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Computer Wizard)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Computer professionals and AIs</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Reduce Familiarity penalties for computers. Roll Hacking/Programming to improvise software to reduce equipment penalty.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:9</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Computer Operation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Computer Programming</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Electronics Operation</name>
-			<specialization compare="is">Communications</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Electronics Operation</name>
-			<specialization compare="is">Media</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Electronics Repair</name>
-			<specialization compare="is">Computers</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is">Computer Security</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is">AI</specialization>
-			<category compare="is anything"></category>
-			<amount>1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Clown)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Audiences, circus performers, vaudevillians, and fellow fools</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>+1/level to first influence roll made against one or more audience members after a successful performance.</notes>
-		</modifier>
-		<reference>PU3:8</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Acrobatics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Dancing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fire Eating</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hobby Skill</name>
-			<specialization compare="is">Juggling</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Makeup</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mimicry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Performance</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Singing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sleight of Hand</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Ventriloquism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Close to the Earth)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Those who respect nature</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>IQ-4+Level to notice disturbances in nature</notes>
-		</modifier>
-		<reference>PU3:8</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is">Elementals</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Naturalist</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Religious Ritual</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Theology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Weather Sense</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is">Faeries</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is">Nature Spirits</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Close to Hell)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Demons</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:8</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Exorcism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is">Demons</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Occultism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is">Demons</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Religious Ritual</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Theology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Close to Heaven)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Any fellow &#8220;religious professional&#8221;</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>IQ-4+Level to notice omens and blessed items</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:8</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Meditation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Religious Ritual</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Theology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Ritual Magic</name>
-			<specialization compare="is">@Religion@</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Symbol Drawing</name>
-			<specialization compare="is">@Religion@</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Exorcism</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Circuit Sense)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Anyone for whom you use your skills</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>-1/level less-severe penalties from Familiarity (p. B169) &#8211; which can run to -10 in certain cases (see p. B189) &#8211; when using any skill to operate unfamiliar gear that runs on electricity.</notes>
-		</modifier>
-		<reference>PU3:8</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Electrician</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Electronics Operation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Electronics Repair</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Engineer (Electrical and Electronics)</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Chi Talent)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>15</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus: None</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-		</modifier>
-		<reference>PU3:7</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Autohypnosis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Blind Fighting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Body Control</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Breaking Blow</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Breath Control</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Esoteric Medicine</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Flying Leap</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Immovable Stance</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Invisibility Art</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Kiai</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Light Walk</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mental Strength</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mind Block</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Parry Missile Weapons</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Power Blow</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pressure Points</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pressure Secrets</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Push</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Throwing Art</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Zen Archery</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Chi Talent)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>15</points_per_level>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">5</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:7</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Autohypnosis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Blind Fighting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Body Control</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Breaking Blow</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Breath Control</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Esoteric Medicine</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Flying Leap</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Immovable Stance</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Invisibility Art</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Kiai</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Light Walk</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mental Strength</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Mind Block</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Parry Missile Weapons</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Power Blow</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pressure Points</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Pressure Secrets</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Push</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Throwing Art</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Zen Archery</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Business Acumen)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus: Anyone with whom you do business.</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-2</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:7</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Accounting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Administration</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Economics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Finance</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Gambling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Market Analysis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Merchant</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Propaganda</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Born War Leader)</name>
-		<type>Physical</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<reference>DF1:14,PU3:12</reference>
-		<categories>
-			<category>Advantage</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">leadership</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">strategy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="starts with">tactics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">intelligence analysis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">savoir-faire</name>
-			<specialization compare="is">military</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Born to Be Wired)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Hackers; people buying stock in your dot-com.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>-1/level less-severe penalties from Familiarity (p. B169) for unfamiliar computer equipment, and/or success at Computer Hacking or Computer Programming lets you improvise code that removes -1/level from the penalty for not having proper software for a task that requires it (p. B345).</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:8</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Computer Hacking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Computer Operation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Computer Programming</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Cryptography</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Electronics Repair (Computers)</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill (Computer Security)</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Born Tactician)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Anyone you serve with or command</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to initiative rolls if leader</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-2</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:12</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">History</name>
-			<specialization compare="contains">Military</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Intelligence Analysis</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Leadership</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Savoir-Faire</name>
-			<specialization compare="is">Military</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Soldier</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Strategy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Tactics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is anything">Military Science</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Born Spacer)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Professional Spacers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>+1/Level to ST for zero G push off.  Reduce penalty for unfamiliar spacecraft.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:7</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Aerobatics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Free Fall</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Navigation</name>
-			<specialization compare="is">Space</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Piloting</name>
-			<specialization compare="is">High-Performance Spacecraft</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Piloting</name>
-			<specialization compare="is">Low-Performance Spacecraft</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Piloting</name>
-			<specialization compare="is">Aerospace</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Spacer</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Vacc Suit</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Born Soldier)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Those you serve with or command</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Reduce chance of impersonal battlefield hazards</notes>
-		</modifier>
-		<reference>PU3:12</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Leadership</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Savoir-Faire</name>
-			<specialization compare="is anything">Military</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Scrounging</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Soldier</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Tactics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Born Sailor)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Sailors</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to resist seasickness and reduce unfamiliarity penalties for system on an appropriate boat or ship</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:13</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Boating</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Knot-Tying</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Meteorology</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Navigation</name>
-			<specialization compare="is">Sea</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Seamanship</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shiphandling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Weather Sense</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<prereq_list all="yes">
-			<advantage_prereq has="no">
-				<name compare="is">Talent (Mariner)</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Born Entertainer)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Crowds</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>+1/level to first influence roll made against one or more audience members after a successful performance.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:6</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">acting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">dancing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">performance</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">public speaking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">singing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">stage combat</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Beastmaster)</name>
-		<type>Mental, Supernatural</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Animals</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">2</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:6</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">animal handling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">disguise</name>
-			<specialization compare="is anything">animals</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">falconry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">flight</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">hidden lore</name>
-			<specialization compare="is">lycanthropes</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">mimicry</name>
-			<specialization compare="is">animal sounds</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">mimicry</name>
-			<specialization compare="is">bird calls</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">mount</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">naturalist</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">packing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">riding</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">teamster</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">veterinary</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount>1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Bard)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Audiences and fellow bards</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to first influence roll made against one or more audience members after a successful performance.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:6</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">heraldry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">literature</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">musical influence</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">poetry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">public speaking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">singing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Artificer)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Employers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Eliminate -1/level to a skill with success on another to improvise tools; Apply to Enigmatic Device Table rolls and other unskilled tech rolls.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Cost</name>
-			<cost type="points">-1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:6</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">armoury</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">carpentry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">electrician</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">electronics repair</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">engineer</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">machinist</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">masonry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">mechanic</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">smith</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Antiquary)</name>
-		<type>Physical</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus: Devotees of the old and beautiful.</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternative Benefit</name>
-			<cost type="points">1</cost>
-			<affects>levels only</affects>
-		</modifier>
-		<reference>PU3:6</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Architecture</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Connoisseur</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Heraldry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">History</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Literature</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Research</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Animal Friend)</name>
-		<type>Physical</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<reference>PU3:6</reference>
-		<notes>Reaction Bonus: All ordinary animals</notes>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Animal Handling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Falconry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Packing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Riding</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Teamster</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Veterinary</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Allure)</name>
-		<type>Physical</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<reference>PU3:6</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Dancing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Erotic Art</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Makeup</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sex Appeal</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Singing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Alien Friend)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Aliens</notes>
-		</modifier>
-		<reference>PU3:6</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Diplomacy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is">Xenology</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Anthropology</name>
-			<specialization compare="is">@Alien@</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">History</name>
-			<specialization compare="is">@Alien@</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Psychology</name>
-			<specialization compare="is">@Alien@</specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Talent (Academic)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Bonus</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Students and teachers</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Alternate Benefit</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>+1/Level to any roll that benefits from Eidetic Memory</notes>
-		</modifier>
-		<reference>PU3:6</reference>
-		<categories>
-			<category>Advantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Public Speaking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Research</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Speed-Reading</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Teaching</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Writing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Taboo Traits (@Subject@)</name>
-		<type></type>
-		<base_points>-1</base_points>
-		<reference>PU6:21</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Symbol-Shy</name>
+		<name>Can&#8217;t Read Music</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
 		<reference>PU6:31</reference>
@@ -6477,108 +1066,187 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Swinging</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:16</reference>
+		<name>Care (@Subject@)</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
 		<categories>
-			<category>Cinematic</category>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Careful</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:17</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Careful planner</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:30</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Carrier (@Disease@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Suspicious</name>
+		<name>Carries backup weapons</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:30</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Charm (@Spell@)</name>
+		<type>Supernatural</type>
+		<base_points>1</base_points>
+		<reference>PU2:19</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Chauvinistic</name>
 		<type>Mental, Social</type>
 		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
+		<reference>PU6:17</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Susceptible to @Item@</name>
-		<type>Physical</type>
+		<name>Cheaper (@Gear@; @Percentage@%)</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<reference>PU2:8</reference>
+		<notes>@Reason@</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Checkered Past</name>
+		<type>Social</type>
 		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
+		<reference>PU6:32</reference>
+		<notes>@Subject@</notes>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Sure-Footed (Water)</name>
-		<type>Physical</type>
+		<name>Chi Resistance (@Chi-based Effect@)</name>
+		<type>Supernatural</type>
 		<base_points>1</base_points>
-		<reference>PU2:8</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sure-Footed (Uneven)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:8</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sure-Footed (Snow)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:8</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sure-Footed (Slippery)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:8</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sure-Footed (Sand)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:8</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sure-Footed (Ice)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:8</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sure-Footed (@Surface@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:8</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Supersuit</name>
-		<type>Physical, Supernatural</type>
-		<base_points>1</base_points>
-		<reference>PU2:9</reference>
+		<reference>PU2:19</reference>
 		<categories>
 			<category>Cinematic</category>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Superstition</name>
+		<name>Citizenship (@State@)</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<modifier version="1" enabled="no">
+			<name>Home</name>
+			<cost type="points">-1</cost>
+			<affects>total</affects>
+			<notes>You get one free citizenship.</notes>
+		</modifier>
+		<reference>PU2:17</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Classic Features (@Features@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:4</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Clean freak</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:30</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Climbing Line</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:10</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Clinch (Boxing)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Clinch (Brawling)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Clinch (Karate)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Cloaked</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Clumsy Runner</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Code of Honor</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
 		<reference>PU6:9</reference>
@@ -6588,54 +1256,7 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Supernatural Features</name>
-		<type>Supernatural</type>
-		<base_points>-1</base_points>
-		<reference>PU6:34</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Supernatural Dislike</name>
-		<type>Supernatural</type>
-		<base_points>-1</base_points>
-		<reference>PU6:34</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sunburns Easily</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Suit Familiarity (@Environment Suit skill@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:9</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Successful at @Ability@</name>
-		<type></type>
-		<base_points>-1</base_points>
-		<reference>PU6:21</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Substance Intolerance (@Subject@)</name>
+		<name>Cold Intolerance</name>
 		<type>Physical</type>
 		<base_points>-1</base_points>
 		<reference>PU6:25</reference>
@@ -6644,467 +1265,45 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Style Familiarity (@Style@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Strongbow</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Striking Surface</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:12</reference>
-		<notes>Requires DR 3+ without Flexible, Force Field, or Tough Skin.</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="is">Damage Resistance</name>
-				<notes compare="is anything"></notes>
-				<level compare="at least">3</level>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Stereotype (@Subject@)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:16</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Standard Operating Procedure (On Alert)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Standard Operating Procedure (Off-Screen Reload)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Standard Operating Procedure (Last Man Out)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Standard Operating Procedure (Full Tank)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Standard Operating Procedure (Energizer)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Standard Operating Procedure (Back to the Wall)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Staid</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Spirit Contract (@Patron@)</name>
-		<type>Social, Supernatural</type>
-		<base_points>1</base_points>
-		<reference>PU2:20</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Spell Susceptibility (@Spell@)</name>
-		<type>Supernatural</type>
-		<base_points>-1</base_points>
-		<reference>PU6:34</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Spell Signature</name>
-		<type>Supernatural</type>
-		<base_points>-1</base_points>
-		<reference>PU6:34</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Special Setup (@New setup &gt; Technique@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Special Exercises (@Attribute, Characteristics or Advantage@)</name>
-		<type></type>
-		<levels>1</levels>
-		<points_per_level>1</points_per_level>
-		<reference>PU2:21</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Soft Spot (@Group@)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:27</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Slow Reflexes</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Slightly Unusual Biochemistry</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sleepyhead</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sleepy Drinker</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:29</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sleeptalker</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sleep of the Dead</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Skintight</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Skill Adaptation (@Specific skill use@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:17</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Show-Off (@Skill@)</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:32</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-		<prereq_list all="yes">
-			<skill_prereq has="yes">
-				<name compare="is">@Skill@</name>
-				<specialization compare="is anything"></specialization>
-				<level compare="at least">1</level>
-			</skill_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Shoves and Tackles (@Long Weapon@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Shocking Affectation</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Shield-Wall Training</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sharpens weapons at every opportunity</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:30</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Shaky Hands</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sexy Pose</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<notes>Non-Verbal Sex Appeal</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sexless</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:23</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Serious</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Self-Imposed Limit</name>
+		<name>Collector (@Subject@)</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
 		<reference>PU6:27</reference>
-		<notes>@Subject@</notes>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Secretive</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Secret Styles (@Move Name@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Secret Powers</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:33</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Secret Knowledge (@Skill@)</name>
-		<type></type>
-		<base_points>1</base_points>
-		<reference>PU2:20</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sea Legs</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Scales</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:12</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sartorial Integrity</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sanitized Metabolism</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:12</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Sacrificial Parry (@Weapon@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Rules Exemption (@Rule@)</name>
-		<type></type>
-		<base_points>1</base_points>
-		<reference>PU2:20</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Rules Exclusion (@Rule@)</name>
-		<type></type>
-		<base_points>-1</base_points>
-		<reference>PU6:21</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Rule of 17 (@Skill@)</name>
-		<type>Supernatural</type>
-		<base_points>1</base_points>
-		<reference>PU2:20</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Rule of 15 (@Class of skills@)</name>
+		<name>College Incompetence (@Subject@)</name>
 		<type>Supernatural</type>
 		<base_points>-1</base_points>
 		<reference>PU6:34</reference>
-		<notes>Requires at least one applicable skill at 16+.</notes>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Rule of 15</name>
-		<type>Mental</type>
+		<name>Combat Hesitancy</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Combat Vaulting (@Reach 2+ Polearm Skill@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Compact Frame</name>
+		<type>Physical</type>
 		<base_points>1</base_points>
 		<reference>PU2:13</reference>
 		<categories>
@@ -7112,26 +1311,37 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Robust (@Sense@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Risk-Taking Behavior</name>
-		<type>Mental</type>
+		<name>Complicated</name>
+		<type>Social</type>
 		<base_points>-1</base_points>
-		<reference>PU6:30</reference>
+		<reference>PU6:32</reference>
+		<notes>@Subject@</notes>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Rinse</name>
-		<type>Physical, Exotic</type>
+		<name>Compulsion</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:27</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Congenial</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:17</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Controllable Disadvantage (@Disadvantage@)</name>
+		<type>Mental</type>
 		<base_points>1</base_points>
 		<reference>PU2:12</reference>
 		<categories>
@@ -7139,268 +1349,26 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Restricted Casting Style</name>
-		<type>Supernatural</type>
-		<base_points>-1</base_points>
-		<reference>PU6:34</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Restless Sleeper</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Rest in Pieces</name>
-		<type>Supernatural</type>
-		<base_points>1</base_points>
-		<reference>PU2:19</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Responsive</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Responsible</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Resistant to @Specific Poison@</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<notes>+3 to resist</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Residual Personality</name>
-		<type>Supernatural</type>
-		<base_points>-1</base_points>
-		<reference>PU6:34</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Reproductive Control (Reabsorption)</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:12</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Reproductive Control (Fertility Control)</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:12</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Religious Belief (@Subject@)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:8</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Red Tape</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:33</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Record-Keeper</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:29</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Reach Mastery (@Weapon@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<notes>Let you change reach as a free action</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Razor Kicks</name>
+		<name>Controllable Disadvantage (@Disadvantage@)</name>
 		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:7</reference>
+		<reference>PU2:13</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Rapid Retraction (Punches)</name>
-		<type>Physical</type>
+		<name>Convincing Nod</name>
+		<type>Mental/Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:7</reference>
+		<reference>PU2:15</reference>
+		<notes>Non-Verbal Fast-Talk</notes>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Rapid Retraction (Kicks)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Rapid Retraction (Bites)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Quick-Swap (@Weapon@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Quick-Sheathe (@Weapon@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Purpose (@Purpose@)</name>
-		<type>Supernatural</type>
-		<base_points>1</base_points>
-		<reference>PU2:19</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Proud</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Pretense</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:33</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Pressure-Tolerant Lungs</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:11</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Preferred Tactics</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:26</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Preferred Looks</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:26</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Practical Joker</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:30</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Power Grappling</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Positive Secret</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:33</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Posh</name>
+		<name>Cooperative</name>
 		<type>Mental, Social</type>
 		<base_points>-1</base_points>
 		<reference>PU6:18</reference>
@@ -7409,314 +1377,36 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Poor Night Vision</name>
-		<type>Physical</type>
+		<name>Cosmetic Eyeglasses</name>
+		<type>Physical, Social</type>
 		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
+		<reference>PU6:13</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Pistol-Fist (@Pistol Skill@)</name>
-		<type>Mental</type>
+		<name>Cotton Stomach</name>
+		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:6</reference>
+		<reference>PU2:5</reference>
 		<categories>
 			<category>Cinematic</category>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Photosensitivity</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:24</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Photogenic</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:4</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Philosophical Belief (@Subject@)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:8</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Pet (@Type@)</name>
+		<name>Courtesy Title (@Title@)</name>
 		<type>Social</type>
-		<base_points>1</base_points>
+		<levels>1</levels>
+		<points_per_level>1</points_per_level>
 		<reference>PU2:18</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Personality Change</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Permit (@Type@)</name>
-		<type>Social</type>
-		<base_points>1</base_points>
-		<reference>PU2:18</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Periscope</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:11</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Perfume</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:11</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Perfectionist</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Penetrating Voice</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Peg-Leg Fighting</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="starts with">Lame</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Patience of Job</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Passing Appearance (Passing Complexion)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:4</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Passing Appearance (Androgynous)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:4</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Passing Appearance (@Group@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:4</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Parthenogenesis</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:11</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Pants-Positive Safety</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Pain-Sensitive</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:23</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Overweight</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:23</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Overspecialization (@Skill@)</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:31</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-		<prereq_list all="yes">
-			<skill_prereq has="yes">
-				<name compare="is">@Skill@</name>
-				<specialization compare="is anything"></specialization>
-				<level compare="at least">1</level>
-			</skill_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Overcautious Habit</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:30</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>One-Way Literacy (@Language@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>One-Way Fluency (@Language@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>One-Task Wonder (@Task@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:17</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>One-Armed Bandit (@Guns Skill@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Office (@Type@)</name>
-		<type>Social</type>
-		<base_points>1</base_points>
-		<reference>PU2:18</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Off-Hand Training (@Skill@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:16</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Odious Personal Habit</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Obvious</name>
-		<type>Physical, Exotic</type>
-		<base_points>-1</base_points>
-		<reference>PU6:12</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Obsession (@Subject@)</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:29</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Obscure True Name</name>
+		<name>Covenant of Rest</name>
 		<type>Social, Supernatural</type>
 		<base_points>1</base_points>
 		<reference>PU2:19</reference>
@@ -7725,41 +1415,25 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Nosy</name>
-		<type>Mental</type>
+		<name>Credulous</name>
+		<type>Mental, Social</type>
 		<base_points>-1</base_points>
-		<reference>PU6:20</reference>
+		<reference>PU6:18</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Nostalgic</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:19</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>No Visible Damage</name>
+		<name>Cross-Species Surrogacy (@Species@)</name>
 		<type>Physical, Exotic</type>
 		<base_points>1</base_points>
-		<reference>PU2:11</reference>
+		<reference>PU2:10</reference>
 		<categories>
-			<category>Cinematic</category>
 			<category>Perk</category>
 		</categories>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="is">Unkillable</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
 	</advantage>
 	<advantage version="3">
-		<name>No Nuisance Rolls (@Task@)</name>
+		<name>Cross-Trained (@Skill@)</name>
 		<type>Mental/Physical</type>
 		<base_points>1</base_points>
 		<reference>PU2:16</reference>
@@ -7769,396 +1443,408 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>No Hangover</name>
+		<name>Crossbow Finesse</name>
 		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:14</reference>
+		<reference>PU2:7</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>No Degeneration in Zero-G</name>
-		<type>Physical, Exotic</type>
+		<name>Cutting Edge Training (@Skill@)</name>
+		<type>Mental/Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:11</reference>
+		<reference>PU2:16</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Never raises voice</name>
+		<name>Cyclothymic</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
-		<reference>PU6:30</reference>
+		<reference>PU6:17</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Neutered</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:23</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Nervous Stomach</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:25</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Neck Control (@Unarmed Striking Skill@)</name>
-		<type>Physical</type>
+		<name>Dabbler</name>
+		<type>Mental/Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:6</reference>
+		<reference>PU2:16</reference>
+		<notes>@Up to 8 Skills@</notes>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Naval Training</name>
+		<name>Daily Ritual</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:28</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Damned</name>
+		<type>Supernatural</type>
+		<base_points>-1</base_points>
+		<reference>PU6:34</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dead Giveaway</name>
+		<type>Physical, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:13</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dead Weight</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Decisive</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:17</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Deep Sleeper</name>
 		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:6</reference>
+		<reference>PU2:13</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Natural Pockets</name>
+		<name>Delusion</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:17</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Delusional Competence (@Skill@)</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:17</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Desirous</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:18</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Determined</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:18</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dirty Fighting</name>
 		<type>Mental</type>
 		<base_points>1</base_points>
-		<reference>PU2:14</reference>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Disarming Smile</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<notes>Non-Verbal Diplomacy</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Disciplined</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:18</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dishonest Face</name>
+		<type>Physical, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:14</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dislike (@Subject@)</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:26</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Disorganized</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:18</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Disposable Identity</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<reference>PU2:18</reference>
 		<notes>@Details@</notes>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Nano-Fever</name>
-		<type>Physical, Exotic</type>
+		<name>Distinctive Features</name>
+		<type>Physical, Social</type>
 		<base_points>-1</base_points>
-		<reference>PU6:12</reference>
+		<reference>PU6:14</reference>
+		<notes>@Subject@</notes>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Named Possession (@Name@)</name>
-		<type>Social, Supernatural</type>
-		<base_points>1</base_points>
-		<reference>PU2:19</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Name-Bound</name>
-		<type>Supernatural</type>
-		<base_points>-1</base_points>
-		<reference>PU6:34</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Missing Toes</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:23</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Missing Teeth</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:23</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Minor Handicap (@Subject@)</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:23</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Minor Alcoholism</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:29</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Minor Addiction (@Subject@)</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:29</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Mind-Numbing Magnetism</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Mild Dyslexia</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:31</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Methodical</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:19</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Math-Shy</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:31</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Masked</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Magic School Familiarity (@School@)</name>
-		<type>Mental, Social, Supernatural</type>
-		<base_points>1</base_points>
-		<reference>PU2:19</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Low-Pressure Intolerance</name>
-		<type>Physical, Exotic</type>
-		<base_points>-1</base_points>
-		<reference>PU6:12</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Low-Frequency Hearing Loss</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:23</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Low Rejection Threshold</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Loud Voice</name>
+		<name>Distinctive Speech</name>
 		<type>Mental, Social</type>
 		<base_points>-1</base_points>
 		<reference>PU6:16</reference>
+		<notes>@Subject@</notes>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Looks Good in Uniform</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Long Fingers</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:11</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Literal-Minded</name>
+		<name>Distractible</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
-		<reference>PU6:19</reference>
+		<reference>PU6:18</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Limited Colorblindness</name>
+		<name>Doesn&#8217;t trust banks</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:30</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Doodad</name>
+		<type></type>
+		<levels>1</levels>
+		<points_per_level>1</points_per_level>
+		<reference>PU2:9</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dorky</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:18</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dramatic Death</name>
+		<type>Supernatural</type>
+		<base_points>1</base_points>
+		<reference>PU2:19</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dreamer</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:18</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Drunken Fighting</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dual Identity</name>
+		<type>Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:33</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dual Ready (@Single Handed Weapon Skill@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dull</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:18</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dull Smell</name>
 		<type>Physical</type>
 		<base_points>-1</base_points>
-		<reference>PU6:23</reference>
+		<reference>PU6:22</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Limited Camouflage (@Environment@)</name>
-		<type>Physical, Exotic</type>
+		<name>Dull Taste</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Dull Taste and Smell</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Easily Mistaken Sex</name>
+		<type>Physical, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:14</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Easily Winded</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Eavesdropper</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:28</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Efficient (@Skill@)</name>
+		<type>Mental/Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:11</reference>
+		<reference>PU2:16</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Like (@Subject@)</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:26</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>License (@Type@)</name>
+		<name>Emeritus Professor</name>
 		<type>Social</type>
-		<base_points>1</base_points>
+		<levels>1</levels>
+		<points_per_level>1</points_per_level>
 		<reference>PU2:18</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Legalistic</name>
-		<type>Mental</type>
+		<name>Epitome (@Subject@)</name>
+		<type>Mental/Physical, Social</type>
 		<base_points>-1</base_points>
-		<reference>PU6:9</reference>
+		<reference>PU6:14</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Lazy Skill (@Attribute@-based @Skill@)</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:31</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-		<prereq_list all="yes">
-			<skill_prereq has="yes">
-				<name compare="is">@Skill@</name>
-				<specialization compare="is anything"></specialization>
-			</skill_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Layabout</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:19</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Job Hunter</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
+		<name>Ex-Cop</name>
+		<type>Social</type>
+		<levels>1</levels>
+		<points_per_level>1</points_per_level>
+		<reference>PU2:18</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Iron Body Parts (Iron Neck)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Iron Body Parts (Iron Legs)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Iron Body Parts (Iron Hands)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Iron Body Parts (Iron Arms)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Involuntary Utterance</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:16</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Intuitive Repairman (@Item@)</name>
+		<name>Exotic Equipment Training (@Equipment@)</name>
 		<type>Mental</type>
 		<base_points>1</base_points>
 		<reference>PU2:9</reference>
@@ -8167,103 +1853,106 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Intolerance (@Small Group@)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:26</reference>
+		<name>Exotic Weapon Training (@Weapon@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
 		<categories>
-			<category>Quirk</category>
+			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Interviews Badly</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Insensitive</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:19</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Incompetence (@Skill@)</name>
+		<name>Expensive Habit (@Subject@)</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
-		<reference>PU6:31</reference>
+		<reference>PU6:28</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
-		<prereq_list all="yes">
-			<skill_prereq has="no">
-				<name compare="is">@Skill@</name>
-				<specialization compare="is anything"></specialization>
-			</skill_prereq>
-		</prereq_list>
 	</advantage>
 	<advantage version="3">
-		<name>Inappropriate Manner (Wishy-Washy)</name>
-		<type>Mental, Social</type>
+		<name>Extended Hearing (High)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Extended Hearing (Low)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>External Mood Influence</name>
+		<type>Mental</type>
 		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
+		<reference>PU6:18</reference>
+		<notes>@Subject@</notes>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Inappropriate Manner (Scummy)</name>
-		<type>Mental, Social</type>
+		<name>Extra Drawback (@Rule@)</name>
+		<type></type>
 		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
+		<reference>PU6:21</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Inappropriate Manner (Salacious)</name>
-		<type>Mental, Social</type>
+		<name>Extra Option (@Rule@)</name>
+		<type></type>
+		<base_points>1</base_points>
+		<reference>PU2:20</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Extreme Sexual Dimorphism</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:10</reference>
+		<notes>+1 to attempts to identify you, -1 to attempts to remain anonymous.</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Sex Appeal</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount>1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Eye for Distance</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>False Memory</name>
+		<type>Mental</type>
 		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
+		<reference>PU6:17</reference>
+		<notes>@Subject@</notes>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Inappropriate Manner (Pushy)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Inappropriate Manner (Oily)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Inappropriate Manner (Aristocratic)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Inappropriate Manner (@Subject@)</name>
+		<name>Fashion Disaster</name>
 		<type>Mental, Social</type>
 		<base_points>-1</base_points>
 		<reference>PU6:14</reference>
@@ -8272,7 +1961,7 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Inaccessible Idioms</name>
+		<name>Fast Talker</name>
 		<type>Mental, Social</type>
 		<base_points>-1</base_points>
 		<reference>PU6:16</reference>
@@ -8281,16 +1970,103 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Improvised Weapons (@Combat Skill@)</name>
+		<name>Fatigues Easily Under Loads</name>
 		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Favor Owed</name>
+		<type>Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:32</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Fearsome Stare</name>
+		<type>Mental/Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:6</reference>
+		<reference>PU2:15</reference>
+		<notes>Non-Verbal Intimidation</notes>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Impatient</name>
+		<name>Feathers</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:10</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Flirtatious</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:28</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Flourish (@Weapon Skill@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<notes>Intimidate at +4 with ready after kill/knockdown</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Focused (@Task@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Focused Fury</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<notes>Combine Mighty Blows and All Out Attack</notes>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Follow-Through (@Weapon Skill@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<notes>Intimidate as free action after kill/knockdown</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Forbidden Word (@Word@)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:16</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Forgetful</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
 		<reference>PU6:19</reference>
@@ -8299,7 +2075,219 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Immunity to @Specific Disease@</name>
+		<name>Forgettable Face</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:4</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+		<prereq_list all="yes">
+			<advantage_prereq has="no">
+				<name compare="is">Unnatural Features</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+			<advantage_prereq has="no">
+				<name compare="is">Distinctive Features</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Form Mastery (@Weapon@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:5</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Former Alcoholic</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:29</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Friend</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<reference>PU2:18</reference>
+		<notes>@Details@</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Friendly Drunk</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:29</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Fur</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:10</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Gangster Swagger</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<notes>Non-Verbal Streetwise</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Generator</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:10</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Glimpses of Clarity</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:19</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Good with @Animal@</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Good with @Social Group@</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Grip Mastery (@Weapon@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Ground Guard</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Grudge</name>
+		<type>Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:32</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Hands Free (@Skill@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:16</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Hated by @Group@</name>
+		<type>Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:33</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Haughty Sneer</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<notes>Non-Verbal Savoir-Faire (High Society)</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Headhunter</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Heat Intolerance</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:25</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Hedonist</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:28</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>High Rejection Threshold</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:22</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>High-Frequency Hearing Loss</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:23</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>High-Heeled Heroine</name>
 		<type>Physical</type>
 		<base_points>1</base_points>
 		<reference>PU2:14</reference>
@@ -8308,12 +2296,227 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Immunity to (@Specific Hazard/Poison/Disease@)</name>
+		<name>High-Pressure Intolerance</name>
 		<type>Physical, Exotic</type>
+		<base_points>-1</base_points>
+		<reference>PU6:12</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Hoarder</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:28</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Honest Face</name>
+		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:11</reference>
+		<reference>PU2:4</reference>
 		<categories>
 			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Horrible Hangovers</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:29</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Huge Weapons (SM)</name>
+		<type>Physical, Exotic</type>
+		<levels>1</levels>
+		<points_per_level>1</points_per_level>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Huge Weapons (ST)</name>
+		<type>Physical, Exotic</type>
+		<levels>1</levels>
+		<points_per_level>1</points_per_level>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Humble</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:19</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Hungry</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:23</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Hyper-Specialization (@Skill@; @Specialty@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:16</reference>
+		<notes>+5 to specialty</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Idealistic</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:19</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Ignition</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:10</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Ill-Advised Hobby (@Subject@)</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:28</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Illumination</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:10</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Imaginative</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:19</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Imbue</name>
+		<type>Mental, Supernatural</type>
+		<modifier version="1" enabled="no">
+			<name>Imbue level 1</name>
+			<reference>PU1:4</reference>
+			<cost type="points">10</cost>
+			<affects>total</affects>
+			<notes>Novice imbuement skills available.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Imbue level 2</name>
+			<reference>PU1:4</reference>
+			<cost type="points">20</cost>
+			<affects>total</affects>
+			<notes>Intermediate (and easier) imbuement skills available.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Imbue level 3</name>
+			<reference>PU1:4</reference>
+			<cost type="points">40</cost>
+			<affects>total</affects>
+			<notes>Master (and easier) imbuement skills available.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Chi</name>
+			<reference>PU1:4</reference>
+			<cost type="percentage">-10</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Divine</name>
+			<reference>PU1:4</reference>
+			<cost type="percentage">-10</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Magical</name>
+			<reference>PU1:4</reference>
+			<cost type="percentage">-10</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Psionic</name>
+			<reference>PU1:4</reference>
+			<cost type="percentage">-10</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Power Based</name>
+			<reference>PY12:24</reference>
+			<cost type="percentage">-5</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Cosmic</name>
+			<reference>PU1:4</reference>
+			<cost type="percentage">50</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Ignore DR</name>
+			<reference>PU1:4</reference>
+			<cost type="percentage">300</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Only One Skill</name>
+			<reference>PU1:4</reference>
+			<cost type="percentage">-80</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Only Two Skills</name>
+			<reference>PU1:4</reference>
+			<cost type="percentage">-60</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Only Three Skills</name>
+			<reference>PU1:4</reference>
+			<cost type="percentage">-40</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Only Four Skills</name>
+			<reference>PU1:4</reference>
+			<cost type="percentage">-20</cost>
+			<affects>total</affects>
+		</modifier>
+		<reference>PU1:4</reference>
+		<categories>
+			<category>Imbue</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
@@ -8713,231 +2916,16 @@
 		</skill_bonus>
 	</advantage>
 	<advantage version="3">
-		<name>Imbue</name>
-		<type>Mental, Supernatural</type>
-		<modifier version="1" enabled="no">
-			<name>Imbue level 1</name>
-			<reference>PU1:4</reference>
-			<cost type="points">10</cost>
-			<affects>total</affects>
-			<notes>Novice imbuement skills available.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Imbue level 2</name>
-			<reference>PU1:4</reference>
-			<cost type="points">20</cost>
-			<affects>total</affects>
-			<notes>Intermediate (and easier) imbuement skills available.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Imbue level 3</name>
-			<reference>PU1:4</reference>
-			<cost type="points">40</cost>
-			<affects>total</affects>
-			<notes>Master (and easier) imbuement skills available.</notes>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Chi</name>
-			<reference>PU1:4</reference>
-			<cost type="percentage">-10</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Divine</name>
-			<reference>PU1:4</reference>
-			<cost type="percentage">-10</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Magical</name>
-			<reference>PU1:4</reference>
-			<cost type="percentage">-10</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Psionic</name>
-			<reference>PU1:4</reference>
-			<cost type="percentage">-10</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Power Based</name>
-			<reference>PY12:24</reference>
-			<cost type="percentage">-5</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Cosmic</name>
-			<reference>PU1:4</reference>
-			<cost type="percentage">50</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Ignore DR</name>
-			<reference>PU1:4</reference>
-			<cost type="percentage">300</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Only One Skill</name>
-			<reference>PU1:4</reference>
-			<cost type="percentage">-80</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Only Two Skills</name>
-			<reference>PU1:4</reference>
-			<cost type="percentage">-60</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Only Three Skills</name>
-			<reference>PU1:4</reference>
-			<cost type="percentage">-40</cost>
-			<affects>total</affects>
-		</modifier>
-		<modifier version="1" enabled="no">
-			<name>Only Four Skills</name>
-			<reference>PU1:4</reference>
-			<cost type="percentage">-20</cost>
-			<affects>total</affects>
-		</modifier>
-		<reference>PU1:4</reference>
-		<categories>
-			<category>Imbue</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Imaginative</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:19</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Illumination</name>
+		<name>Immunity to (@Specific Hazard/Poison/Disease@)</name>
 		<type>Physical, Exotic</type>
 		<base_points>1</base_points>
-		<reference>PU2:10</reference>
+		<reference>PU2:11</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Ill-Advised Hobby (@Subject@)</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:28</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Ignition</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:10</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Idealistic</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:19</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Hyper-Specialization (@Skill@; @Specialty@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:16</reference>
-		<notes>+5 to specialty</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Hungry</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:23</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Humble</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:19</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Huge Weapons (ST)</name>
-		<type>Physical, Exotic</type>
-		<levels>1</levels>
-		<points_per_level>1</points_per_level>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Huge Weapons (SM)</name>
-		<type>Physical, Exotic</type>
-		<levels>1</levels>
-		<points_per_level>1</points_per_level>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Horrible Hangovers</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:29</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Honest Face</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:4</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Hoarder</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:28</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>High-Pressure Intolerance</name>
-		<type>Physical, Exotic</type>
-		<base_points>-1</base_points>
-		<reference>PU6:12</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>High-Heeled Heroine</name>
+		<name>Immunity to @Specific Disease@</name>
 		<type>Physical</type>
 		<base_points>1</base_points>
 		<reference>PU2:14</reference>
@@ -8946,126 +2934,7 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>High-Frequency Hearing Loss</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:23</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>High Rejection Threshold</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Hedonist</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:28</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Heat Intolerance</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:25</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Headhunter</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Haughty Sneer</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<notes>Non-Verbal Savoir-Faire (High Society)</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Hated by @Group@</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:33</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Hands Free (@Skill@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:16</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Grudge</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:32</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Ground Guard</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Grip Mastery (@Weapon@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:6</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Good with @Social Group@</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Good with @Animal@</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Glimpses of Clarity</name>
+		<name>Impatient</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
 		<reference>PU6:19</reference>
@@ -9074,91 +2943,197 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Generator</name>
-		<type>Physical, Exotic</type>
+		<name>Improvised Weapons (@Combat Skill@)</name>
+		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:10</reference>
+		<reference>PU2:6</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Gangster Swagger</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<notes>Non-Verbal Streetwise</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Fur</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:10</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Friendly Drunk</name>
-		<type>Mental</type>
+		<name>Inaccessible Idioms</name>
+		<type>Mental, Social</type>
 		<base_points>-1</base_points>
-		<reference>PU6:29</reference>
+		<reference>PU6:16</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Friend</name>
-		<type>Social</type>
-		<base_points>1</base_points>
-		<reference>PU2:18</reference>
-		<notes>@Details@</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Former Alcoholic</name>
-		<type>Mental</type>
+		<name>Inappropriate Manner (@Subject@)</name>
+		<type>Mental, Social</type>
 		<base_points>-1</base_points>
-		<reference>PU6:29</reference>
+		<reference>PU6:14</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Form Mastery (@Weapon@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
+		<name>Inappropriate Manner (Aristocratic)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
 		<categories>
-			<category>Perk</category>
+			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Forgettable Face</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:4</reference>
+		<name>Inappropriate Manner (Oily)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
 		<categories>
-			<category>Perk</category>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Inappropriate Manner (Pushy)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Inappropriate Manner (Salacious)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Inappropriate Manner (Scummy)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Inappropriate Manner (Wishy-Washy)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Incompetence (@Skill@)</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:31</reference>
+		<categories>
+			<category>Quirk</category>
 		</categories>
 		<prereq_list all="yes">
-			<advantage_prereq has="no">
-				<name compare="is">Unnatural Features</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-			<advantage_prereq has="no">
-				<name compare="is">Distinctive Features</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
+			<skill_prereq has="no">
+				<name compare="is">@Skill@</name>
+				<specialization compare="is anything"></specialization>
+			</skill_prereq>
 		</prereq_list>
 	</advantage>
 	<advantage version="3">
-		<name>Forgetful</name>
+		<name>Insensitive</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:19</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Interviews Badly</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Intolerance (@Small Group@)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:26</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Intuitive Repairman (@Item@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:9</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Involuntary Utterance</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:16</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Iron Body Parts (Iron Arms)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Iron Body Parts (Iron Hands)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Iron Body Parts (Iron Legs)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Iron Body Parts (Iron Neck)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Job Hunter</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Layabout</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
 		<reference>PU6:19</reference>
@@ -9167,454 +3142,40 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Forbidden Word (@Word@)</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:16</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Follow-Through (@Weapon Skill@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<notes>Intimidate as free action after kill/knockdown</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Focused Fury</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<notes>Combine Mighty Blows and All Out Attack</notes>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Focused (@Task@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Flourish (@Weapon Skill@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<notes>Intimidate at +4 with ready after kill/knockdown</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Flirtatious</name>
+		<name>Lazy Skill (@Attribute@-based @Skill@)</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
-		<reference>PU6:28</reference>
+		<reference>PU6:31</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
+		<prereq_list all="yes">
+			<skill_prereq has="yes">
+				<name compare="is">@Skill@</name>
+				<specialization compare="is anything"></specialization>
+			</skill_prereq>
+		</prereq_list>
 	</advantage>
 	<advantage version="3">
-		<name>Feathers</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:10</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Fearsome Stare</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<notes>Non-Verbal Intimidation</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Favor Owed</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:32</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Fatigues Easily Under Loads</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Fast Talker</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:16</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Fashion Disaster</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:14</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>False Memory</name>
+		<name>Legalistic</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
-		<reference>PU6:17</reference>
-		<notes>@Subject@</notes>
+		<reference>PU6:9</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Eye for Distance</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Extreme Sexual Dimorphism</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:10</reference>
-		<notes>+1 to attempts to identify you, -1 to attempts to remain anonymous.</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Sex Appeal</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount>1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Extra Option (@Rule@)</name>
-		<type></type>
-		<base_points>1</base_points>
-		<reference>PU2:20</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Extra Drawback (@Rule@)</name>
-		<type></type>
-		<base_points>-1</base_points>
-		<reference>PU6:21</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>External Mood Influence</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Extended Hearing (Low)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Extended Hearing (High)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Expensive Habit (@Subject@)</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:28</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Exotic Weapon Training (@Weapon@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Exotic Equipment Training (@Equipment@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:9</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Ex-Cop</name>
-		<type>Social</type>
-		<levels>1</levels>
-		<points_per_level>1</points_per_level>
-		<reference>PU2:18</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Epitome (@Subject@)</name>
-		<type>Mental/Physical, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:14</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Emeritus Professor</name>
-		<type>Social</type>
-		<levels>1</levels>
-		<points_per_level>1</points_per_level>
-		<reference>PU2:18</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Efficient (@Skill@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:16</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Eavesdropper</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:28</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Easily Winded</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Easily Mistaken Sex</name>
-		<type>Physical, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:14</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dull Taste and Smell</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dull Taste</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dull Smell</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dull</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dual Ready (@Single Handed Weapon Skill@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dual Identity</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:33</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Drunken Fighting</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dreamer</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dramatic Death</name>
-		<type>Supernatural</type>
-		<base_points>1</base_points>
-		<reference>PU2:19</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dorky</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Doodad</name>
-		<type></type>
-		<levels>1</levels>
-		<points_per_level>1</points_per_level>
-		<reference>PU2:9</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Doesn&#8217;t trust banks</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:30</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Distractible</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Distinctive Speech</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:16</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Distinctive Features</name>
-		<type>Physical, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:14</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Disposable Identity</name>
+		<name>License (@Type@)</name>
 		<type>Social</type>
 		<base_points>1</base_points>
 		<reference>PU2:18</reference>
-		<notes>@Details@</notes>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Disorganized</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dislike (@Subject@)</name>
+		<name>Like (@Subject@)</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
 		<reference>PU6:26</reference>
@@ -9623,118 +3184,187 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Dishonest Face</name>
-		<type>Physical, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:14</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Disciplined</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Disarming Smile</name>
-		<type>Mental/Physical</type>
+		<name>Limited Camouflage (@Environment@)</name>
+		<type>Physical, Exotic</type>
 		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<notes>Non-Verbal Diplomacy</notes>
+		<reference>PU2:11</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Dirty Fighting</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Determined</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Desirous</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Delusional Competence (@Skill@)</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:17</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Delusion</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:17</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Deep Sleeper</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Decisive</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:17</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dead Weight</name>
+		<name>Limited Colorblindness</name>
 		<type>Physical</type>
 		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
+		<reference>PU6:23</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Dead Giveaway</name>
-		<type>Physical, Social</type>
+		<name>Literal-Minded</name>
+		<type>Mental</type>
 		<base_points>-1</base_points>
-		<reference>PU6:13</reference>
-		<notes>@Subject@</notes>
+		<reference>PU6:19</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Damned</name>
+		<name>Long Fingers</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:11</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Looks Good in Uniform</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Loud Voice</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:16</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Low Rejection Threshold</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Low-Frequency Hearing Loss</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:23</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Low-Pressure Intolerance</name>
+		<type>Physical, Exotic</type>
+		<base_points>-1</base_points>
+		<reference>PU6:12</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Magic School Familiarity (@School@)</name>
+		<type>Mental, Social, Supernatural</type>
+		<base_points>1</base_points>
+		<reference>PU2:19</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Masked</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Math-Shy</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:31</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Methodical</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:19</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Mild Dyslexia</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:31</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Mind-Numbing Magnetism</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Minor Addiction (@Subject@)</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:29</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Minor Alcoholism</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:29</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Minor Handicap (@Subject@)</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:23</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Missing Teeth</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:23</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Missing Toes</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:23</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Name-Bound</name>
 		<type>Supernatural</type>
 		<base_points>-1</base_points>
 		<reference>PU6:34</reference>
@@ -9743,82 +3373,7 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Daily Ritual</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:28</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Dabbler</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:16</reference>
-		<notes>@Up to 8 Skills@</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Cyclothymic</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:17</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Cutting Edge Training (@Skill@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:16</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Crossbow Finesse</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:7</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Cross-Trained (@Skill@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:16</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Cross-Species Surrogacy (@Species@)</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:10</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Credulous</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Covenant of Rest</name>
+		<name>Named Possession (@Name@)</name>
 		<type>Social, Supernatural</type>
 		<base_points>1</base_points>
 		<reference>PU2:19</reference>
@@ -9827,148 +3382,44 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Courtesy Title (@Title@)</name>
-		<type>Social</type>
-		<levels>1</levels>
-		<points_per_level>1</points_per_level>
-		<reference>PU2:18</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Cotton Stomach</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Cosmetic Eyeglasses</name>
-		<type>Physical, Social</type>
+		<name>Nano-Fever</name>
+		<type>Physical, Exotic</type>
 		<base_points>-1</base_points>
-		<reference>PU6:13</reference>
+		<reference>PU6:12</reference>
 		<categories>
 			<category>Quirk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Cooperative</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Convincing Nod</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:15</reference>
-		<notes>Non-Verbal Fast-Talk</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Controllable Disadvantage (@Disadvantage@)</name>
+		<name>Natural Pockets</name>
 		<type>Mental</type>
 		<base_points>1</base_points>
-		<reference>PU2:12</reference>
+		<reference>PU2:14</reference>
+		<notes>@Details@</notes>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Controllable Disadvantage (@Disadvantage@)</name>
+		<name>Naval Training</name>
 		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:13</reference>
+		<reference>PU2:6</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Congenial</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:17</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Compulsion</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:27</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Complicated</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:32</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Compact Frame</name>
+		<name>Neck Control (@Unarmed Striking Skill@)</name>
 		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:13</reference>
+		<reference>PU2:6</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Combat Vaulting (@Reach 2+ Polearm Skill@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Combat Hesitancy</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>College Incompetence (@Subject@)</name>
-		<type>Supernatural</type>
-		<base_points>-1</base_points>
-		<reference>PU6:34</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Collector (@Subject@)</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:27</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Cold Intolerance</name>
+		<name>Nervous Stomach</name>
 		<type>Physical</type>
 		<base_points>-1</base_points>
 		<reference>PU6:25</reference>
@@ -9977,7 +3428,1224 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Code of Honor</name>
+		<name>Neutered</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:23</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Never raises voice</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:30</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>No Degeneration in Zero-G</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:11</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>No Hangover</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>No Nuisance Rolls (@Task@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:16</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>No Visible Damage</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:11</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+		<prereq_list all="yes">
+			<advantage_prereq has="yes">
+				<name compare="is">Unkillable</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Nostalgic</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:19</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Nosy</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Obscure True Name</name>
+		<type>Social, Supernatural</type>
+		<base_points>1</base_points>
+		<reference>PU2:19</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Obsession (@Subject@)</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:29</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Obvious</name>
+		<type>Physical, Exotic</type>
+		<base_points>-1</base_points>
+		<reference>PU6:12</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Odious Personal Habit</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Off-Hand Training (@Skill@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:16</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Office (@Type@)</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<reference>PU2:18</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>One-Armed Bandit (@Guns Skill@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>One-Task Wonder (@Task@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:17</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>One-Way Fluency (@Language@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>One-Way Literacy (@Language@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Overcautious Habit</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:30</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Overspecialization (@Skill@)</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:31</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+		<prereq_list all="yes">
+			<skill_prereq has="yes">
+				<name compare="is">@Skill@</name>
+				<specialization compare="is anything"></specialization>
+				<level compare="at least">1</level>
+			</skill_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Overweight</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:23</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Pain-Sensitive</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:23</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Pants-Positive Safety</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Parthenogenesis</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:11</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Passing Appearance (@Group@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:4</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Passing Appearance (Androgynous)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:4</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Passing Appearance (Passing Complexion)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:4</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Patience of Job</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Peg-Leg Fighting</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+		<prereq_list all="yes">
+			<advantage_prereq has="yes">
+				<name compare="starts with">Lame</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Penetrating Voice</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Perfectionist</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Perfume</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:11</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Periscope</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:11</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Permit (@Type@)</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<reference>PU2:18</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Personality Change</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Pet (@Type@)</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<reference>PU2:18</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Philosophical Belief (@Subject@)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:8</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Photogenic</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:4</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Photosensitivity</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:24</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Pistol-Fist (@Pistol Skill@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:6</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Poor Night Vision</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:24</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Posh</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:18</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Positive Secret</name>
+		<type>Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:33</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Power Grappling</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Practical Joker</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:30</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Preferred Looks</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:26</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Preferred Tactics</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:26</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Pressure-Tolerant Lungs</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:11</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Pretense</name>
+		<type>Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:33</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Proud</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Purpose (@Purpose@)</name>
+		<type>Supernatural</type>
+		<base_points>1</base_points>
+		<reference>PU2:19</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Quick-Sheathe (@Weapon@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Quick-Swap (@Weapon@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Rapid Retraction (Bites)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Rapid Retraction (Kicks)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Rapid Retraction (Punches)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Razor Kicks</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Reach Mastery (@Weapon@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<notes>Let you change reach as a free action</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Record-Keeper</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:29</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Red Tape</name>
+		<type>Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:33</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Religious Belief (@Subject@)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:8</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Reproductive Control (Fertility Control)</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:12</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Reproductive Control (Reabsorption)</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:12</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Residual Personality</name>
+		<type>Supernatural</type>
+		<base_points>-1</base_points>
+		<reference>PU6:34</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Resistant to @Specific Poison@</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<notes>+3 to resist</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Responsible</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Responsive</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Rest in Pieces</name>
+		<type>Supernatural</type>
+		<base_points>1</base_points>
+		<reference>PU2:19</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Restless Sleeper</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:24</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Restricted Casting Style</name>
+		<type>Supernatural</type>
+		<base_points>-1</base_points>
+		<reference>PU6:34</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Rinse</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:12</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Risk-Taking Behavior</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:30</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Robust (@Sense@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Rule of 15</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:13</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Rule of 15 (@Class of skills@)</name>
+		<type>Supernatural</type>
+		<base_points>-1</base_points>
+		<reference>PU6:34</reference>
+		<notes>Requires at least one applicable skill at 16+.</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Rule of 17 (@Skill@)</name>
+		<type>Supernatural</type>
+		<base_points>1</base_points>
+		<reference>PU2:20</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Rules Exclusion (@Rule@)</name>
+		<type></type>
+		<base_points>-1</base_points>
+		<reference>PU6:21</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Rules Exemption (@Rule@)</name>
+		<type></type>
+		<base_points>1</base_points>
+		<reference>PU2:20</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sacrificial Parry (@Weapon@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sanitized Metabolism</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:12</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sartorial Integrity</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Scales</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:12</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sea Legs</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Secret Knowledge (@Skill@)</name>
+		<type></type>
+		<base_points>1</base_points>
+		<reference>PU2:20</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Secret Powers</name>
+		<type>Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:33</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Secret Styles (@Move Name@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Secretive</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Self-Imposed Limit</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:27</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Serious</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sexless</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:23</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sexy Pose</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<notes>Non-Verbal Sex Appeal</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Shaky Hands</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:24</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sharpens weapons at every opportunity</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:30</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Shield-Wall Training</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Shocking Affectation</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Shoves and Tackles (@Long Weapon@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Show-Off (@Skill@)</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:32</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+		<prereq_list all="yes">
+			<skill_prereq has="yes">
+				<name compare="is">@Skill@</name>
+				<specialization compare="is anything"></specialization>
+				<level compare="at least">1</level>
+			</skill_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Skill Adaptation (@Specific skill use@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:17</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Skintight</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:14</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sleep of the Dead</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:24</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sleeptalker</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:24</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sleepy Drinker</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:29</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sleepyhead</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:24</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Slightly Unusual Biochemistry</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:24</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Slow Reflexes</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:24</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Soft Spot (@Group@)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:27</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Special Exercises (@Attribute, Characteristics or Advantage@)</name>
+		<type></type>
+		<levels>1</levels>
+		<points_per_level>1</points_per_level>
+		<reference>PU2:21</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Special Setup (@New setup &gt; Technique@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Spell Signature</name>
+		<type>Supernatural</type>
+		<base_points>-1</base_points>
+		<reference>PU6:34</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Spell Susceptibility (@Spell@)</name>
+		<type>Supernatural</type>
+		<base_points>-1</base_points>
+		<reference>PU6:34</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Spirit Contract (@Patron@)</name>
+		<type>Social, Supernatural</type>
+		<base_points>1</base_points>
+		<reference>PU2:20</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Staid</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Standard Operating Procedure (Back to the Wall)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Standard Operating Procedure (Energizer)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Standard Operating Procedure (Full Tank)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Standard Operating Procedure (Last Man Out)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Standard Operating Procedure (Off-Screen Reload)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Standard Operating Procedure (On Alert)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:15</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Stereotype (@Subject@)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:16</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Striking Surface</name>
+		<type>Physical, Exotic</type>
+		<base_points>1</base_points>
+		<reference>PU2:12</reference>
+		<notes>Requires DR 3+ without Flexible, Force Field, or Tough Skin.</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+		<prereq_list all="yes">
+			<advantage_prereq has="yes">
+				<name compare="is">Damage Resistance</name>
+				<notes compare="is anything"></notes>
+				<level compare="at least">3</level>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Strongbow</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Style Familiarity (@Style@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:7</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Substance Intolerance (@Subject@)</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:25</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Successful at @Ability@</name>
+		<type></type>
+		<base_points>-1</base_points>
+		<reference>PU6:21</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Suit Familiarity (@Environment Suit skill@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:9</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Sunburns Easily</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:24</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Supernatural Dislike</name>
+		<type>Supernatural</type>
+		<base_points>-1</base_points>
+		<reference>PU6:34</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Supernatural Features</name>
+		<type>Supernatural</type>
+		<base_points>-1</base_points>
+		<reference>PU6:34</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Superstition</name>
 		<type>Mental</type>
 		<base_points>-1</base_points>
 		<reference>PU6:9</reference>
@@ -9987,294 +4655,18 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Clumsy Runner</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Cloaked</name>
-		<type>Physical</type>
+		<name>Supersuit</name>
+		<type>Physical, Supernatural</type>
 		<base_points>1</base_points>
-		<reference>PU2:14</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Clinch (Karate)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Clinch (Brawling)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Clinch (Boxing)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Climbing Line</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:10</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Clean freak</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:30</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Classic Features (@Features@)</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:4</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Citizenship (@State@)</name>
-		<type>Social</type>
-		<base_points>1</base_points>
-		<modifier version="1" enabled="no">
-			<name>Home</name>
-			<cost type="points">-1</cost>
-			<affects>total</affects>
-			<notes>You get one free citizenship.</notes>
-		</modifier>
-		<reference>PU2:17</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Chi Resistance (@Chi-based Effect@)</name>
-		<type>Supernatural</type>
-		<base_points>1</base_points>
-		<reference>PU2:19</reference>
+		<reference>PU2:9</reference>
 		<categories>
 			<category>Cinematic</category>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Checkered Past</name>
-		<type>Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:32</reference>
-		<notes>@Subject@</notes>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Cheaper (@Gear@; @Percentage@%)</name>
-		<type>Social</type>
-		<base_points>1</base_points>
-		<reference>PU2:8</reference>
-		<notes>@Reason@</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Chauvinistic</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:17</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Charm (@Spell@)</name>
-		<type>Supernatural</type>
-		<base_points>1</base_points>
-		<reference>PU2:19</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Carries backup weapons</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:30</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Carrier (@Disease@)</name>
+		<name>Sure-Footed (@Surface@)</name>
 		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:13</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Careful planner</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:30</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Careful</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:17</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Care (@Subject@)</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Can&#8217;t Read Music</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:31</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Cannot Float</name>
-		<type>Physical, Exotic</type>
-		<base_points>-1</base_points>
-		<reference>PU6:12</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Can Be Turned By True Faith</name>
-		<type>Supernatural</type>
-		<base_points>-1</base_points>
-		<reference>PU6:33</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Call of the Wild</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:12</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="is">Animal Empathy</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Burrower</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:10</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Bulky Frame</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Brotherhood (@Group@)</name>
-		<type>Social</type>
-		<base_points>1</base_points>
-		<reference>PU2:17</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Broad-Minded</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:17</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Bowlegged</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Born Goon</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:18</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Biting Mastery</name>
-		<type>Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Better (@Gear@)</name>
-		<type>Social</type>
 		<base_points>1</base_points>
 		<reference>PU2:8</reference>
 		<categories>
@@ -10282,911 +4674,61 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Base</name>
-		<type>Social</type>
-		<base_points>1</base_points>
-		<reference>PU2:17</reference>
-		<notes>@Description@</notes>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Bad Posture</name>
-		<type>Physical, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:13</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Background Knowledge (@Background@)</name>
-		<type>Mental/Physical</type>
-		<base_points>1</base_points>
-		<reference>PU2:16</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Autotrance</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:12</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Attentive</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:17</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Atheist</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:8</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Armorer&#8217;s Gift (@Weapon Skill@)</name>
+		<name>Sure-Footed (Ice)</name>
 		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:5</reference>
+		<reference>PU2:8</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Armor Familiarity (@Combat Skill@)</name>
-		<type>Physical</type>
-		<levels>1</levels>
-		<points_per_level>1</points_per_level>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Anti-Talent (Unsubtle)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>-5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Penalty</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Sneaky people and anyone who catches you in the act</notes>
-		</modifier>
-		<modifier version="1">
-			<name>Additional Drawback</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Bonus to others' rolls to notice or remember you</notes>
-		</modifier>
-		<reference>PU3:21</reference>
-		<categories>
-			<category>Disadvantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Camouflage</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Disguise</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Holdout</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Shadowing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Smuggling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Stealth</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Anti-Talent (Noncombatant)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>-15</points_per_level>
-		<modifier version="1">
-			<name>Reaction Penalty</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Anyone who would react poorly to Cowardice</notes>
-		</modifier>
-		<reference>PU3:21</reference>
-		<notes>Penalty to all combat rolls except active defenses, which are based on reduced skills instead</notes>
-		<categories>
-			<category>Disadvantage</category>
-			<category>Talent</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Anti-Talent (Misfit)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>-15</points_per_level>
-		<modifier version="1">
-			<name>Reaction Penalty</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Anyone you try to impress</notes>
-		</modifier>
-		<modifier version="1">
-			<name>Additional Drawback</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Penalty to resist Influence skills and manipulation</notes>
-		</modifier>
-		<reference>PU3:20</reference>
-		<categories>
-			<category>Disadvantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Acting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Administration</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Carousing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Connoisseur</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Detect Lies</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Diplomacy</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Fast-Talk</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Gambling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Gesture</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Intimidation</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Leadership</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Merchant</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Politics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Propaganda</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Public Speaking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Savoir-Faire</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sex Appeal</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is"></name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Teaching</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Anti-Talent (Mind like a Sieve)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>-5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Penalty</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Anybody who values knowledge</notes>
-		</modifier>
-		<modifier version="1">
-			<name>Additional Drawback</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Penalty anywhere Eidetic Memory would give a bonus</notes>
-		</modifier>
-		<reference>PU3:20</reference>
-		<categories>
-			<category>Disadvantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Area Knowledge</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Connoisseur</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Current Affairs</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Expert Skill</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hidden Lore</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hobby Skill</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Anti-Talent (Couch Potato)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>-10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Penalty</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Athletes, fitness nuts, and anyone with higher HT than you</notes>
-		</modifier>
-		<modifier version="1">
-			<name>Additional Drawback</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Penalty to recover from injuries due to physical feats</notes>
-		</modifier>
-		<reference>PU3:20</reference>
-		<categories>
-			<category>Disadvantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Acrobatics</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Bicycling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Climbing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Hiking</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Jumping</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Lifting</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Running</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Skating</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Skiing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Sports</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Swimming</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Throwing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Anti-Talent (Animal Foe)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>-5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Penalty</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>All animals, all the time</notes>
-		</modifier>
-		<modifier version="1">
-			<name>Additional Drawback</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>Penalty to evaluate animals</notes>
-		</modifier>
-		<reference>PU3:20</reference>
-		<categories>
-			<category>Disadvantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">Animal Handling</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Falconry</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Packing</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Riding</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Teamster</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">Veterinary</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Anti-Talent (@Small@)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>-5</points_per_level>
-		<modifier version="1">
-			<name>Reaction Penalty</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>@Reaction Penalty@</notes>
-		</modifier>
-		<modifier version="1">
-			<name>Additional Drawback</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>@Additional Drawback@</notes>
-		</modifier>
-		<reference>PU3:19</reference>
-		<categories>
-			<category>Disadvantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">@skill1@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill2@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill3@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill4@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill5@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill6@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Anti-Talent (@Medium@)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>-10</points_per_level>
-		<modifier version="1">
-			<name>Reaction Penalty</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>@Reaction Penalty@</notes>
-		</modifier>
-		<modifier version="1">
-			<name>Additional Drawback</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>@Additional Drawback@</notes>
-		</modifier>
-		<reference>PU3:19</reference>
-		<categories>
-			<category>Disadvantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">@skill01@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill02@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill03@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill04@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill05@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill06@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill07@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill08@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill09@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill10@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill11@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill12@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Anti-Talent (@Large@)</name>
-		<type>Mental</type>
-		<levels>1</levels>
-		<points_per_level>-15</points_per_level>
-		<modifier version="1">
-			<name>Reaction Penalty</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>@Reaction Penalty@</notes>
-		</modifier>
-		<modifier version="1">
-			<name>Additional Drawback</name>
-			<cost type="percentage">0</cost>
-			<affects>total</affects>
-			<notes>@Additional Drawback@</notes>
-		</modifier>
-		<reference>PU3:19</reference>
-		<categories>
-			<category>Disadvantage</category>
-			<category>Talent</category>
-		</categories>
-		<skill_bonus>
-			<name compare="is">@skill01@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill02@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill03@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill04@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill05@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill06@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill07@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill08@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill09@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill10@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill11@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill12@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill13@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill14@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill15@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill16@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-		<skill_bonus>
-			<name compare="is">@skill17@</name>
-			<specialization compare="is anything"></specialization>
-			<category compare="is anything"></category>
-			<amount per_level="yes">-1</amount>
-		</skill_bonus>
-	</advantage>
-	<advantage version="3">
-		<name>Amoral</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:15</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Allergy (@Subject@)</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Alcohol Tolerance</name>
+		<name>Sure-Footed (Sand)</name>
 		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:13</reference>
+		<reference>PU2:8</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Alcohol Intolerance</name>
-		<type>Mental</type>
-		<base_points>-1</base_points>
-		<reference>PU6:29</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Akimbo (@Weapon Skill@)</name>
+		<name>Sure-Footed (Slippery)</name>
 		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Cinematic</category>
-			<category>Perk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Air Jet</name>
-		<type>Physical, Exotic</type>
-		<base_points>1</base_points>
-		<reference>PU2:10</reference>
+		<reference>PU2:8</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Affected by Magnetism</name>
-		<type>Physical, Exotic</type>
-		<base_points>-1</base_points>
-		<reference>PU6:12</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Admiration</name>
-		<type>Mental, Social</type>
-		<base_points>-1</base_points>
-		<reference>PU6:25</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Acrobatic Feints</name>
+		<name>Sure-Footed (Snow)</name>
 		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:5</reference>
+		<reference>PU2:8</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Aches and Pains</name>
-		<type>Physical</type>
-		<base_points>-1</base_points>
-		<reference>PU6:22</reference>
-		<categories>
-			<category>Quirk</category>
-		</categories>
-	</advantage>
-	<advantage version="3">
-		<name>Accessory (@Accessory@)</name>
+		<name>Sure-Footed (Uneven)</name>
 		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:10</reference>
+		<reference>PU2:8</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Accent (@Language@; @Region@)</name>
-		<type>Physical, Exotic</type>
+		<name>Sure-Footed (Water)</name>
+		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:5</reference>
-		<categories>
-			<category>Perk</category>
-		</categories>
-		<prereq_list all="yes">
-			<advantage_prereq has="yes">
-				<name compare="is">Language: @Language@</name>
-				<notes compare="is anything"></notes>
-			</advantage_prereq>
-		</prereq_list>
-	</advantage>
-	<advantage version="3">
-		<name>Accent (@Language@)</name>
-		<type>Mental</type>
-		<base_points>1</base_points>
-		<reference>PU2:12</reference>
+		<reference>PU2:8</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Acceleration Weakness</name>
+		<name>Susceptible to @Item@</name>
 		<type>Physical</type>
 		<base_points>-1</base_points>
 		<reference>PU6:24</reference>
@@ -11195,16 +4737,6356 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>Acceleration Tolerance</name>
+		<name>Suspicious</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Swinging</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:16</reference>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Symbol-Shy</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:31</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Taboo Traits (@Subject@)</name>
+		<type></type>
+		<base_points>-1</base_points>
+		<reference>PU6:21</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Academic)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Students and teachers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>+1/Level to any roll that benefits from Eidetic Memory</notes>
+		</modifier>
+		<reference>PU3:6</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Public Speaking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Research</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Speed-Reading</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Teaching</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Writing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Alien Friend)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Aliens</notes>
+		</modifier>
+		<reference>PU3:6</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Diplomacy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is">Xenology</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Anthropology</name>
+			<specialization compare="is">@Alien@</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">History</name>
+			<specialization compare="is">@Alien@</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is">@Alien@</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Allure)</name>
+		<type>Physical</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<reference>PU3:6</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Dancing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Erotic Art</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Makeup</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sex Appeal</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Singing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Animal Friend)</name>
+		<type>Physical</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<reference>PU3:6</reference>
+		<notes>Reaction Bonus: All ordinary animals</notes>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Animal Handling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Falconry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Packing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Riding</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Teamster</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Veterinary</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Antiquary)</name>
+		<type>Physical</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus: Devotees of the old and beautiful.</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Benefit</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:6</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Architecture</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Connoisseur</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Heraldry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">History</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Literature</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Research</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Artificer)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Employers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Eliminate -1/level to a skill with success on another to improvise tools; Apply to Enigmatic Device Table rolls and other unskilled tech rolls.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:6</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">armoury</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">carpentry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">electrician</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">electronics repair</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">engineer</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">machinist</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">masonry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">mechanic</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">smith</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Bard)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Audiences and fellow bards</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to first influence roll made against one or more audience members after a successful performance.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:6</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">heraldry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">literature</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">musical influence</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">poetry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">public speaking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">singing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Beastmaster)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Animals</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">2</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:6</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">animal handling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">disguise</name>
+			<specialization compare="is anything">animals</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">falconry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">flight</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">hidden lore</name>
+			<specialization compare="is">lycanthropes</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">mimicry</name>
+			<specialization compare="is">animal sounds</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">mimicry</name>
+			<specialization compare="is">bird calls</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">mount</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">naturalist</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">packing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">riding</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">teamster</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">veterinary</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount>1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Born Entertainer)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Crowds</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>+1/level to first influence roll made against one or more audience members after a successful performance.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:6</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">acting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">dancing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">performance</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">public speaking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">singing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">stage combat</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Born Sailor)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Sailors</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to resist seasickness and reduce unfamiliarity penalties for system on an appropriate boat or ship</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:13</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Boating</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Knot-Tying</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Meteorology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Navigation</name>
+			<specialization compare="is">Sea</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Seamanship</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shiphandling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Weather Sense</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="no">
+				<name compare="is">Talent (Mariner)</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Born Soldier)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Those you serve with or command</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Reduce chance of impersonal battlefield hazards</notes>
+		</modifier>
+		<reference>PU3:12</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Leadership</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Savoir-Faire</name>
+			<specialization compare="is anything">Military</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Scrounging</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Soldier</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Tactics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Born Spacer)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Professional Spacers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>+1/Level to ST for zero G push off.  Reduce penalty for unfamiliar spacecraft.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:7</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Aerobatics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Free Fall</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Navigation</name>
+			<specialization compare="is">Space</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Piloting</name>
+			<specialization compare="is">High-Performance Spacecraft</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Piloting</name>
+			<specialization compare="is">Low-Performance Spacecraft</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Piloting</name>
+			<specialization compare="is">Aerospace</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Spacer</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Vacc Suit</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Born Tactician)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Anyone you serve with or command</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to initiative rolls if leader</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-2</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:12</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">History</name>
+			<specialization compare="contains">Military</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Intelligence Analysis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Leadership</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Savoir-Faire</name>
+			<specialization compare="is">Military</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Soldier</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Strategy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Tactics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is anything">Military Science</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Born to Be Wired)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Hackers; people buying stock in your dot-com.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>-1/level less-severe penalties from Familiarity (p. B169) for unfamiliar computer equipment, and/or success at Computer Hacking or Computer Programming lets you improvise code that removes -1/level from the penalty for not having proper software for a task that requires it (p. B345).</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:8</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Computer Hacking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Computer Operation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Computer Programming</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Cryptography</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Electronics Repair (Computers)</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill (Computer Security)</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Born War Leader)</name>
+		<type>Physical</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<reference>DF1:14,PU3:12</reference>
+		<categories>
+			<category>Advantage</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">leadership</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">strategy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="starts with">tactics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">intelligence analysis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">savoir-faire</name>
+			<specialization compare="is">military</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Business Acumen)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus: Anyone with whom you do business.</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-2</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:7</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Accounting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Administration</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Economics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Finance</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Gambling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Market Analysis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Merchant</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Propaganda</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Chi Talent)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>15</points_per_level>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">5</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:7</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Autohypnosis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Blind Fighting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Body Control</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Breaking Blow</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Breath Control</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Esoteric Medicine</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Flying Leap</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Immovable Stance</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Invisibility Art</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Kiai</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Light Walk</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mental Strength</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mind Block</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Parry Missile Weapons</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Power Blow</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pressure Points</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pressure Secrets</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Push</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Throwing Art</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Zen Archery</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Chi Talent)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>15</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus: None</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+		</modifier>
+		<reference>PU3:7</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Autohypnosis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Blind Fighting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Body Control</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Breaking Blow</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Breath Control</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Esoteric Medicine</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Flying Leap</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Immovable Stance</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Invisibility Art</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Kiai</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Light Walk</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mental Strength</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mind Block</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Parry Missile Weapons</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Power Blow</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pressure Points</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pressure Secrets</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Push</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Throwing Art</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Zen Archery</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Circuit Sense)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Anyone for whom you use your skills</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>-1/level less-severe penalties from Familiarity (p. B169) &#8211; which can run to -10 in certain cases (see p. B189) &#8211; when using any skill to operate unfamiliar gear that runs on electricity.</notes>
+		</modifier>
+		<reference>PU3:8</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Electrician</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Electronics Operation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Electronics Repair</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Engineer (Electrical and Electronics)</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Close to Heaven)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Any fellow &#8220;religious professional&#8221;</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>IQ-4+Level to notice omens and blessed items</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:8</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Meditation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Religious Ritual</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Theology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Ritual Magic</name>
+			<specialization compare="is">@Religion@</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Symbol Drawing</name>
+			<specialization compare="is">@Religion@</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Exorcism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Close to Hell)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Demons</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:8</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Exorcism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is">Demons</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Occultism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is">Demons</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Religious Ritual</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Theology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Close to the Earth)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Those who respect nature</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>IQ-4+Level to notice disturbances in nature</notes>
+		</modifier>
+		<reference>PU3:8</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is">Elementals</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Naturalist</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Religious Ritual</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Theology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Weather Sense</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is">Faeries</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is">Nature Spirits</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Clown)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Audiences, circus performers, vaudevillians, and fellow fools</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>+1/level to first influence roll made against one or more audience members after a successful performance.</notes>
+		</modifier>
+		<reference>PU3:8</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Acrobatics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Dancing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fire Eating</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hobby Skill</name>
+			<specialization compare="is">Juggling</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Makeup</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mimicry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Performance</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Singing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sleight of Hand</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Ventriloquism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Computer Wizard)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Computer professionals and AIs</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Reduce Familiarity penalties for computers. Roll Hacking/Programming to improvise software to reduce equipment penalty.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:9</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Computer Operation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Computer Programming</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Electronics Operation</name>
+			<specialization compare="is">Communications</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Electronics Operation</name>
+			<specialization compare="is">Media</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Electronics Repair</name>
+			<specialization compare="is">Computers</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is">Computer Security</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is">AI</specialization>
+			<category compare="is anything"></category>
+			<amount>1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Craftiness)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus: None</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:9</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Camouflage</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Disguise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Holdout</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shadowing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Stealth</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Acting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Cultural Chameleon)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Other cultures in their lands</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:9</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Anthropology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Diplomacy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Gesture</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Linguistics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sociology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Cunning Folk)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Local peasantry, clients, and acolytes.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Benefit</name>
+			<cost type="points">-2</cost>
+			<affects>levels only</affects>
+			<notes>A roll at IQ-4, +1/level of Cunning Folk, to notice anything odd &#8211; curses, blights, faeries in the basement, etc. &#8211; that happens to animals, crops, or people in an area where you&#8217;ve lived for at least (6 - Cunning Folk level) months.</notes>
+		</modifier>
+		<reference>PU3:9</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Animal Handling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fortune-Telling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Herb Lore</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Naturalist</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Occultism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Poisons</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Veterinary</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Weather Sense</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Cyberneticist)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Other computer professionals, AI systems, and robots</notes>
+		</modifier>
+		<reference>PU3:9</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Computer Hacking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Computer Operation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Computer Programming</name>
+			<specialization compare="is"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Computer Programming</name>
+			<specialization compare="is">AI</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Electronics Repair</name>
+			<specialization compare="is">Computers</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Devotion)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Coreligionists and sympathizers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to will to resist "evil influences"</notes>
+		</modifier>
+		<reference>PU3:9</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Autohypnosis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Exorcism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Meditation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Religious Ritual</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Driver's Reflexes)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Passengers; gamblers betting on you at the Grand Prix.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>+1/level on Per rolls to notice dangers in the path of your ride: running children, oncoming vehicles, landmines...</notes>
+		</modifier>
+		<reference>PU3:10</reference>
+		<categories>
+			<category>Advantage</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Boating</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Driving</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Piloting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Submarine</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Dungeon Artificer)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Potential Buyers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Roll appropriate skill to scrounge equipment for other covered skills and apply level against the penalty.  Shift rolls to avoid ill effects from mysterious artifacts by level in either direction.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:10</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Alchemy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Armoury</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Engineer</name>
+			<specialization compare="is">Gadgets</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fast-Draw</name>
+			<specialization compare="is">Gadgets</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Scrounging</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Traps</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Elder Gift)</name>
+		<type>Mental, Exotic, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Elder Things</notes>
+		</modifier>
+		<reference>PU3:6</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Alchemy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Occultism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Thaumatology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Empath)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>IQ-4+level roll as for Empathy</notes>
+		</modifier>
+		<reference>PU3:10</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Body Language</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Detect Lies</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Diplomacy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fortune-Telling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Explorer)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Fellow explorers and backers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Reduce distance and area class penalties for all skills</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">0</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:10</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Area Knowledge</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Cartography</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Geography</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mathematics</name>
+			<specialization compare="is">Surveying</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Navigation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Forceful Chi)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>15</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Honourable opponents, Hard stylists, Lovers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to be heard or to Intimidation after using a covered skill</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:7</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Breaking Blow</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Erotic Art</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Flying Leap</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hypnotic Hands</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hypnotism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Invisibility Art</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Kiai</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Power Blow</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Precognitive Parry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pressure Points</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pressure Secrets</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Push</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Throwing Art</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Zen Archery</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Forensics Whiz Kid)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Crime-lab employers and detectives</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to Per to spot clues when no skill applies</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Chemistry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Criminology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Diagnosis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Forensics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Research</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Forest Guardian)</name>
+		<type>Mental, Exotic, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Druids, Faeries, and bunnies</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to notice intruders, etc in woodland where you've lived from 6-level months.</notes>
+		</modifier>
+		<reference>PU3:10</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Bow</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Camouflage</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fast-Draw</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Stealth</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Survival</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="yes">
+				<name compare="ends with">Elf</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Gifted Artist)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Buyers and Critics</notes>
+		</modifier>
+		<reference>PU3:10</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Artist</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Jeweler</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Leatherworking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Photography</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sewing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Goodwife)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Beneficiaries, prospective spouses, other housewives</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to defaults made in your own home to repair, maintain, and protect it.</notes>
+		</modifier>
+		<reference>PU3:10</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Cooking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Diagnosis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Gardening</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Housekeeping</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sewing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Green Thumb)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Gardeners and Sentient plants</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to rolls to survive made by plants in your care.</notes>
+		</modifier>
+		<reference>PU3:11</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Biology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Farming</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Gardening</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Herb Lore</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Naturalist</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Healer)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Patients</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to HT rolls for a specific patient and condition if treated full time.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:11</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Diagnosis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Esoteric Medicine</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">First Aid</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pharmacy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Physician</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Physiology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Surgery</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Veterinary</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="no">
+				<name compare="is">Talent (Healer)</name>
+				<notes compare="contains">Modern</notes>
+				<level compare="at least">1</level>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Healer)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Patients</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to HT rolls for a specific patient and condition if treated full time.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:11</reference>
+		<notes>Modern</notes>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Diagnosis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Esoteric Medicine</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">First Aid</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pharmacy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Physician</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Physiology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Surgery</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Veterinary</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Electronics Operation</name>
+			<specialization compare="is">Medical</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is">Epidemiology</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="no">
+				<name compare="is">Talent (Healer)</name>
+				<notes compare="does not contain">Modern</notes>
+				<level compare="at least">1</level>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Hot Pilot)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Other Pilots</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Reduce penalties for unfamiliar systems of vehicles you have Piloting skill for</notes>
+		</modifier>
+		<reference>PU3:11</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Gunner</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Navigation</name>
+			<specialization compare="is">Air</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Navigation</name>
+			<specialization compare="is">Space</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Piloting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Impersonator)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus in contests against covered skills</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:11</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Acting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Body Language</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Disguise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mimicry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Savoir-Faire</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Streetwise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Inner Balance)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>15</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Pacifists, Ascetics, Soft stylists</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to resist mundane disease</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:7</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Autohypnosis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Blind Fighting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Body Control</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Body Language</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Body Sense</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Breath Control</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Dreaming</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Immovable Stance</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Light Walk</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Lizard Climb</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Meditation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mental Strength</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mind Block</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sensitivity</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Intuitive Admiral (Sea))</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Anyone you serve with or command</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to initiative roll if leader</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-2</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:12</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is">Military Science</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">History</name>
+			<specialization compare="ends with">Military</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Intelligence Analysis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Leadership</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Savoir-Faire</name>
+			<specialization compare="is">Military</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shiphandling</name>
+			<specialization compare="is">Ship</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shiphandling</name>
+			<specialization compare="is">Submarine</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Seamanship</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Strategy</name>
+			<specialization compare="is">Sea</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Submariner</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Intuitive Admiral (Space))</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Anyone you serve with or command</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to initiative roll if leader</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-2</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:12</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is">Military Science</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">History</name>
+			<specialization compare="ends with">Military</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Intelligence Analysis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Leadership</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Savoir-Faire</name>
+			<specialization compare="is">Military</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shiphandling</name>
+			<specialization compare="is">Spaceship</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shiphandling</name>
+			<specialization compare="is">Starship</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Spacer</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Strategy</name>
+			<specialization compare="is">Space</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Intuitive Statesman)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Political Parties seeking candidates, those who put you in power</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to influence rolls to be chosen over another for a job or posting, or to cover up a failure with a covered skill.</notes>
+		</modifier>
+		<reference>PU3:11</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Administration</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Current Affairs</name>
+			<specialization compare="is">Headline News</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Current Affairs</name>
+			<specialization compare="is">People</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Current Affairs</name>
+			<specialization compare="is">Politics</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Diplomacy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Economics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Law</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Leadership</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Politics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Propaganda</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Public Speaking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Jack of All Trades)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<reference>PU3:11</reference>
+		<notes>Bonus to all defaults from attributes</notes>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Mariner)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Seafarers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to resist seasicknes and reduce unfamiliarity penalties for system on an appropriate boat or ship</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-3</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:13</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Boating</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Freight Handling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Knot-Tying</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Meteorology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Navigation</name>
+			<specialization compare="is">Sea</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Seamanship</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shiphandling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Weather Sense</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="no">
+				<name compare="is">Talent (Born Sailor)</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Master Builder)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Workers on projects, prospective employers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to avoid common workplace hazards, even if used as traps</notes>
+		</modifier>
+		<reference>PU3:11</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Architecture</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Carpentry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Engineer</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Forced Entry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Masonry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Mathematical Ability)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Engineers and scientists</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to resist deception involving numbers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-2</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:12</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Accounting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Astronomy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Cryptography</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Engineer</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Finance</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Market Analysis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mathematics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Physics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Memetics)</name>
+		<type>Mental, Exotic</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Other memeticists who see you working</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to resist Brainwashing, Fast-Talk, and Propaganda</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">2</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:12</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Brainwashing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Diplomacy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is anything">Memetics</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fast-Talk</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Interrogation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Leadership</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Merchant</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Politics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Propaganda</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sociology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Teaching</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Mesmerist)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>The foolish and weak-minded.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>+1/level to resist any of the affected skills.</notes>
+		</modifier>
+		<reference>PU3:12</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Autohypnosis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Brainwashing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Captivate</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Gesture</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hypnotism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Intimidation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Musical Influence</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Persuade</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Suggest</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sway Emotions</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Mr. Smash)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to intimidate when victim at your mercy and you are threatening with a covered weapon</notes>
+		</modifier>
+		<reference>PU3:13</reference>
+		<notes>Covers Forced-Entry, but only when used with a swung Two Handed weapon.</notes>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Polearm</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Two-Handed Axe/Mace</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Two-Handed Flail</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Two-Handed Sword</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Musical Ability)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Audiences and Critics</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to first influence roll made against one or more audience members after a successful performance.</notes>
+		</modifier>
+		<reference>PU3:13</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Group Performance</name>
+			<specialization compare="is">Conducting</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Musical Composition</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Musical Influence</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Musical Instrument</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Singing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Natural Athlete)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Sports fans, coaches, and recruiters</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to HT to recover from injuries resulting from failures with covered skills</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:13</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Bicycling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Breath Control</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hiking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Jumping</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Lifting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Running</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Skating</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Skiing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sports</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Swimming</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Throwing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Natural Copper)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Police and PIs</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to unskilled Per rolls to notice clues, and to all rolls to use Intuition</notes>
+		</modifier>
+		<reference>PU3:13</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Body Language</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Criminology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Detect Lies</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Intelligence Analysis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Interrogation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Observation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Savoir-Faire</name>
+			<specialization compare="is anything">Police</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Search</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shadowing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Streetwise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Natural Diver)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Expert divers and aquatic beings</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to HT for breath holding time and resisting the Bends, Nitrogen Narcosis, etc.</notes>
+		</modifier>
+		<reference>PU3:13</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Aquabatics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Diving Suit</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Scuba</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is anything">Submarine</name>
+			<specialization compare="is">Free-Flooding Sub</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Swimming</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Natural Scientist)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Scientists and those impressed by "smart people"</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Reduce TL and familiarity penalties for gear examined for an hour with a covered skill</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:13</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Astronomy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Chemistry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is anything">Hydrology</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is anything">Natural Philosophy</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Geology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mathematics</name>
+			<specialization compare="is anything">Applied</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mathematics</name>
+			<specialization compare="is anything">Statistics</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mathematics</name>
+			<specialization compare="is anything">Surveying</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Metallurgy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Meteorology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Paleontology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Physics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pysiology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Ninja Talent)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1" enabled="no">
+			<name>Power Talent</name>
+			<reference>DF12:4</reference>
+			<cost type="points">5</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:7</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Blind Fighting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hypnotism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Invisibility Art</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Light Walk</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mental Strength</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Occultist)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Students of the arcane, gullible college students, monster-hunters.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Benefit</name>
+			<cost type="points">2</cost>
+			<affects>levels only</affects>
+			<notes>+1/level to Fright Checks caused by supernatural beings and effects, and by reading sanity-destroying tomes (because you know what to expect).</notes>
+		</modifier>
+		<reference>PU3:14</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Alchemy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Anthropology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Archaeology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Exorcism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">History</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Linguistics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Literature</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Occultism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Research</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Ritual Magic</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Thaumatology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Outdoorsman)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Explorers and nature lovers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to HT rolls to avoid harm from failure of covered skills</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-3</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:14</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Camouflage</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fishing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mimicry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Naturalist</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Navigation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Survival</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Tracking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Parapsychologist)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Psis and beleivers</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to resist powers that have been examined with covered skills</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:14</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Electronics Operation</name>
+			<specialization compare="is anything">Medical</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Electronics Operation</name>
+			<specialization compare="is anything">Psychotronics</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Electronics Operation</name>
+			<specialization compare="is anything">Scientific</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is anything">Psionics</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hypnotism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Occultism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Physics</name>
+			<specialization compare="is anything">Paraphysics</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Pickaxe Penchant)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Miners</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to will for Extra Effort when digging, HT on failure at such, and all rolls to avoid disasters in mines</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">0</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:14</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Axe/Mace</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Forced Entry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Prospecting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Thrown Weapon</name>
+			<specialization compare="is anything">Axe/Mace</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Two-Handed Axe/Mace</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="yes">
+				<name compare="is">Dwarf</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Poet)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Readers and listeners of your work; literati.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>+1/level to the first Influence roll (p. B359) of any kind made on an audience member (or several of them as a group) after a successful performance.</notes>
+		</modifier>
+		<reference>PU3:14</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Connoisseur (Literature)</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Literature</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Poetry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Public Speaking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Writing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Pop Culture Maven)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Obsessive pop culture devotees</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to Influence or Carousing to demonstrate you are "cool".</notes>
+		</modifier>
+		<reference>PU3:14</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Connoisseur</name>
+			<specialization compare="is anything">Virtual Reality Arts</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Current Affairs</name>
+			<specialization compare="is anything">People</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Current Affairs</name>
+			<specialization compare="is anything">Popular Culture</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Current Affairs</name>
+			<specialization compare="is anything">Sports</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is anything">Memetics</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Psientist)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Psis</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to self control rolls after a successful Meditation, Mental Strength, or Mind Block</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:15</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Hypnotism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Meditation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mental Strength</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Mind Block</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is">Psionics</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is">Psionics</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Sage)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Scholars, students, and people who consult you</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to IQ defaults to non-covered skills for general knowledge only</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">2</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:15</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Archaeology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Geography</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Heraldry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">History</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Law</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Literature</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Occultism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Philosophy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Research</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Theology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Seafarer)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Sailors, pirates, and aquatic races sympathetic to sea travel</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to resist seasicknes and reduce unfamiliarity penalties for system on an appropriate boat or ship. Bonus to Carousing and Streetwise in port towns.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:14</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Boating</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fishing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Knot-Tying</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Meteorology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Weather Sense</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Navigation</name>
+			<specialization compare="is anything">Sea</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Seamanship</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Survival</name>
+			<specialization compare="is anything">Island/Beach</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Swimming</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Thrown Weapon</name>
+			<specialization compare="is anything">Harpoon</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="no">
+				<name compare="is">Talent (Born Sailor)</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+			<advantage_prereq has="no">
+				<name compare="is">Talent (Mariner)</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Smooth Operator)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>15</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Con artists, politicians, salesmen, etc. &#8211; but only if you aren&#8217;t trying to manipulate them.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to resist covered skills</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-2</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:15</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Acting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Carousing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Detect Lies</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Diplomacy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fast-Talk</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Intimidation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Leadership</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Panhandling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Politics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Public Speaking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Savoir-Faire</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sex Appeal</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Streetwise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Social Scientist)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Social and political thinkers, theorists, and activists</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to Acting, Disguise, and Fast-Talk to pass as a member of another political/religious group.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:15</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Anthropology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Archaeology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Criminology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Economics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is">Political Science</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Geography</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">History</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Philosophy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sociology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Theology</name>
+			<specialization compare="is">Comparative</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Spirit-Talker)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Spirits</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:15</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Exorcism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fortune-Telling</name>
+			<specialization compare="is anything">Augury</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fortune-Telling</name>
+			<specialization compare="is anything">Dream Interpretation</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is anything">Spirits</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Meditation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Occultism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Theology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Stalker)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Hunters, trackers, etc.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>+1/level to Per rolls to keep track of a specific quarry you&#8217;ve already spotted using other skills.</notes>
+		</modifier>
+		<reference>PU3:15</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Camouflage</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hiking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Navigation (Land)</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Stealth</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Tracking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Strangler)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to Per to notice people sneaking within arms reach of you</notes>
+		</modifier>
+		<reference>PU3:15</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Brawling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Stealth</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Tracking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Wrestling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is"></name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="yes">
+				<name compare="is">Throttler</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Street Smarts)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>10</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Other street operators</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to notice inner city dangers and scams and to Tracking in built up areas.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">-1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:16</reference>
+		<notes>Familiarity with a new city for city specific skills requires 6-level months</notes>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Area Knowledge</name>
+			<specialization compare="is">@City@</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Current Affairs</name>
+			<specialization compare="is">@City@</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Law</name>
+			<specialization compare="is">@City@</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Merchant</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Panhandling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Scrounging</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shadowing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Streetwise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Urban Survival</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="no">
+				<name compare="is">Talent (Street-Smart)</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Street-Smart)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Shady characters in town.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to notice inner city dangers and scams and to Tracking in built up areas.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Merchant</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Panhandling</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Scrounging</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shadowing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Streetwise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Urban Survival</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="no">
+				<name compare="is">Talent (Street Smarts)</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Strong Chi)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Other martial artists, especially potential masters or students.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>+1/level on rolls to be heard (compare Penetrating Voice, p. B101), and to Intimidation attempts made after using one of the affected skills.</notes>
+		</modifier>
+		<reference>PU3:8</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Breaking Blow</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Flying Leap</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Power Blow</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pressure Points</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pressure Secrets</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Super-Spy)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>15</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>All members of the character&#8217;s organization below his Rank, as well as enemy agents of roughly equal Rank who are aware of his identity</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to rank for clearance and aid, but not for authority or pay.</notes>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Acting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Current Affairs</name>
+			<specialization compare="is">Politics</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Detect Lies</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Disguise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Escape</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fast-Talk</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Holdout</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Interrogation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Observation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Pickpocket</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Search</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shadowing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Sleight of Hand</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Stealth</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Tracking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Superior Equilibrioception)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Acrobats, skydivers, and commandos who slide down ropes.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to DX anywhere Perfect Balance would apply</notes>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Acrobatics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Aerobatics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Aquabatics</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Body Sense</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Climbing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Free Fall</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Parachuting</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Survivor)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Scouts, campers, and survivalists.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Scrounging to find simple equipment with offseting improvides equipment penalty.  Must be simple!</notes>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">First Aid</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Knot-Tying</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Naturalist</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Scrounging</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Survival</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Talker)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Investigators and anybody hiring you to investigate</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to resist verbal influence attempts</notes>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Detect Lies</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Diplomacy</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Fast-Talk</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Psychology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Savoir-Faire</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Thanatologist)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Death-worshippers and sapient undead you don&#8217;t try to exorcize or banish</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to fright checks from undead and bodies</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Exorcism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is">Thanatology</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Occultism</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Professional Skill</name>
+			<specialization compare="is">Mortician</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Religious Ritual</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Theology</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Tough Guy)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Most police officers and detectives, bouncers, gangsters, and street thugs</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus to resist Interrogation and Intimidation, and to Fright Checks resulting from encountering murder victims, bloody torture scenes, etc.</notes>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Fast-Talk</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Forced Entry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Intimidation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Shadowing</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Streetwise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Trivia Sponge)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Anybody who cares about trivia</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus anywhere Eidetic Memory gives a bonus</notes>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Area Knowledge</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Current Affairs</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Games</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hobby Skill</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Truth-Seeker)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Anyone who is Curious or harbors Delusions about conspiracies</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Bonus in Contests against attempts to perpetrate a cover-up.</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Detect Lies</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Expert Skill</name>
+			<specialization compare="is">Conspiracy Theory</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Hidden Lore</name>
+			<specialization compare="is">Conspiracies</specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Intelligence Analysis</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Interrogation</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Research</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Unseelie Talent)</name>
+		<type>Mental</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1" enabled="no">
+			<name>Alternative Cost</name>
+			<cost type="points">1</cost>
+			<affects>levels only</affects>
+		</modifier>
+		<reference>PU3:17</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Camouflage</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Disguise</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Scrounging</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Stealth</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Survival Urban Survival</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+	</advantage>
+	<advantage version="3">
+		<name>Talent (Widget-Worker)</name>
+		<type>Mental, Supernatural</type>
+		<levels>1</levels>
+		<points_per_level>5</points_per_level>
+		<modifier version="1">
+			<name>Reaction Bonus</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Those who benefit directly from your skills</notes>
+		</modifier>
+		<modifier version="1" enabled="no">
+			<name>Alternate Benefit</name>
+			<cost type="percentage">0</cost>
+			<affects>total</affects>
+			<notes>Success at an appropriate covered skill lets you scround equipment for another skill and eliminates level of the penalty for improvised equipment. Shift rolls by level to avoid harm from tampering with mundane mechanisms.</notes>
+		</modifier>
+		<reference>PU3:16</reference>
+		<categories>
+			<category>Advantage</category>
+			<category>Talent</category>
+		</categories>
+		<skill_bonus>
+			<name compare="is">Armoury</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Forced Entry</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Lockpicking</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Scrounging</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<skill_bonus>
+			<name compare="is">Traps</name>
+			<specialization compare="is anything"></specialization>
+			<category compare="is anything"></category>
+			<amount per_level="yes">1</amount>
+		</skill_bonus>
+		<prereq_list all="yes">
+			<advantage_prereq has="yes">
+				<name compare="is">Gnome</name>
+				<notes compare="is anything"></notes>
+			</advantage_prereq>
+		</prereq_list>
+	</advantage>
+	<advantage version="3">
+		<name>Tattletale</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:30</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Taunting</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:15</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Teamwork (@Group@)</name>
 		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:13</reference>
+		<reference>PU2:8</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>@Skill@ based on @Stat@</name>
+		<name>Technique Adaptation (@Technique@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:17</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Technique Mastery (@Technique@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:17</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Tests Positive for @Condition@</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:25</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Thin Skull</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:25</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Third Person</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:16</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Timid</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:18</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Tiny Hands</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:25</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Token (@Subject@)</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:16</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Tone-Deaf</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:25</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Trademark</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:30</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Trademark Move</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:8</reference>
+		<notes>@Description@</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Transporter (@Vehicle Skill@)</name>
+		<type>Mental/Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:16</reference>
+		<notes>No rolls for some vehicle tasks.</notes>
+		<categories>
+			<category>Cinematic</category>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Trivial Destiny</name>
+		<type>Supernatural</type>
+		<base_points>1</base_points>
+		<reference>PU2:20</reference>
+		<notes>@Details@</notes>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Trivial Destiny</name>
+		<type>Supernatural</type>
+		<base_points>-1</base_points>
+		<reference>PU6:34</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Trivial Reputation</name>
+		<type>Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:33</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Trivial Reputation (@Description@)</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<reference>PU2:18</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Trivial Secret</name>
+		<type>Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:33</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Twirl (@Weapon Skill@)</name>
 		<type>Mental/Physical</type>
 		<base_points>1</base_points>
 		<reference>PU2:15</reference>
@@ -11213,20 +11095,138 @@
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>@Racial@ Gifts</name>
-		<type>Physical, Exotic</type>
+		<name>Twitchy</name>
+		<type>Physical</type>
+		<base_points>-1</base_points>
+		<reference>PU6:25</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Unarmed Parry (@Weapon@)</name>
+		<type>Physical</type>
 		<base_points>1</base_points>
-		<reference>PU2:12</reference>
-		<notes>May purchase @Traits@</notes>
+		<reference>PU2:8</reference>
 		<categories>
 			<category>Perk</category>
 		</categories>
 	</advantage>
 	<advantage version="3">
-		<name>@Missing Disadvantage@</name>
+		<name>Unbelievable at @Ability@</name>
+		<type></type>
+		<base_points>-1</base_points>
+		<reference>PU6:21</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Uncongenial</name>
+		<type>Mental, Social</type>
+		<base_points>-1</base_points>
+		<reference>PU6:20</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Unique Technique (@Technique@)</name>
+		<type></type>
+		<base_points>1</base_points>
+		<reference>PU2:21</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Unusual Posture (@Task and Posture@)</name>
+		<type>Mental</type>
+		<base_points>1</base_points>
+		<reference>PU2:17</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Unusual Training (@Cinematic Technique@)</name>
+		<type></type>
+		<base_points>1</base_points>
+		<reference>PU2:21</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Unwelcome Accessory (@Subject@)</name>
+		<type>Physical, Exotic</type>
+		<base_points>-1</base_points>
+		<reference>PU6:13</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Variable Quirk</name>
+		<type></type>
+		<base_points>-1</base_points>
+		<reference>PU6:21</reference>
+		<notes>@Subject@</notes>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Vehicle (@Type@)</name>
+		<type>Social</type>
+		<base_points>1</base_points>
+		<reference>PU2:18</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Villain-Worshipper</name>
 		<type>Mental, Social</type>
 		<base_points>-1</base_points>
 		<reference>PU6:15</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Vow (@Subject@)</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:9</reference>
+		<categories>
+			<category>Quirk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Weapon Adaptation (@Weapon@ to @Weapon@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:8</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Weapon Bond (@Specific Weapon@)</name>
+		<type>Physical</type>
+		<base_points>1</base_points>
+		<reference>PU2:9</reference>
+		<categories>
+			<category>Perk</category>
+		</categories>
+	</advantage>
+	<advantage version="3">
+		<name>Willful Ignorance</name>
+		<type>Mental</type>
+		<base_points>-1</base_points>
+		<reference>PU6:9</reference>
+		<notes>@Subject@</notes>
 		<categories>
 			<category>Quirk</category>
 		</categories>

--- a/Library/Pyramid Magazine/Pyramid 120/GURPS Magic Spells (Based on 10).spl
+++ b/Library/Pyramid Magazine/Pyramid 120/GURPS Magic Spells (Based on 10).spl
@@ -25,12 +25,12 @@
 			<attribute_prereq has="yes" which="iq" compare="at least">13</attribute_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (gate)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -98,12 +98,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (water)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -144,12 +144,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (water)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -249,12 +249,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (body control)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -342,17 +342,17 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (movement)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (air)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -459,12 +459,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (earth)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -789,12 +789,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (making &amp; breaking)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -885,12 +885,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (movement)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -916,12 +916,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (plant)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -1254,12 +1254,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (necromancy)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -1604,12 +1604,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (meta)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -1719,12 +1719,12 @@
 		</categories>
 		<prereq_list all="no">
 			<advantage_prereq has="yes">
-				<name compare="is">quintessence</name>
+				<name compare="is">increased quintessence</name>
 				<notes compare="contains">one college (protection)</notes>
 				<level compare="at least">1</level>
 			</advantage_prereq>
 			<advantage_prereq has="yes">
-				<name compare="is">quintessence</name>
+				<name compare="is">increased quintessence</name>
 				<notes compare="is anything"></notes>
 				<level compare="at least">1</level>
 			</advantage_prereq>
@@ -1858,12 +1858,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (water)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -1923,12 +1923,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (weather)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -1957,12 +1957,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (technological)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -1991,12 +1991,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (technological)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -2020,12 +2020,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (light)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -2063,12 +2063,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (plant)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -2144,12 +2144,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (air)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -2177,12 +2177,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (plant)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -2442,12 +2442,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (fire)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -2482,12 +2482,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (technological)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -2528,12 +2528,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (water)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -2651,12 +2651,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (necromancy)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -2706,12 +2706,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (fire)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -2791,12 +2791,12 @@
 			<attribute_prereq has="yes" which="dx" compare="at least">12</attribute_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (meta)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -2826,12 +2826,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (meta)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -2863,12 +2863,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (mind control)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -2893,12 +2893,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (body control)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -2997,12 +2997,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (weather)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -3145,12 +3145,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (mind control)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -3249,12 +3249,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (communication)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -3325,12 +3325,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (meta)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -3423,12 +3423,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (technological)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -3521,12 +3521,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (making &amp; breaking)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -3638,12 +3638,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (gate)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -3699,12 +3699,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (body control)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -3794,12 +3794,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (sound)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -3957,12 +3957,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (body control)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -3998,12 +3998,12 @@
 		</categories>
 		<prereq_list all="no">
 			<advantage_prereq has="yes">
-				<name compare="is">quintessence</name>
+				<name compare="is">increased quintessence</name>
 				<notes compare="contains">one college (meta)</notes>
 				<level compare="at least">1</level>
 			</advantage_prereq>
 			<advantage_prereq has="yes">
-				<name compare="is">quintessence</name>
+				<name compare="is">increased quintessence</name>
 				<notes compare="is anything"></notes>
 				<level compare="at least">1</level>
 			</advantage_prereq>
@@ -4075,12 +4075,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (air)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -4178,12 +4178,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (earth)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -4241,12 +4241,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (fire)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -4380,12 +4380,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (illusion &amp; creation)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -4415,12 +4415,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (illusion &amp; creation)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -4448,12 +4448,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (plant)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -4482,12 +4482,12 @@
 			<attribute_prereq has="yes" which="iq" compare="at least">12</attribute_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (illusion &amp; creation)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -4599,12 +4599,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (water)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -4729,12 +4729,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (meta)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -4759,12 +4759,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (movement)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -4905,12 +4905,12 @@
 		</categories>
 		<prereq_list all="no">
 			<advantage_prereq has="yes">
-				<name compare="is">quintessence</name>
+				<name compare="is">increased quintessence</name>
 				<notes compare="contains">one college (necromancy)</notes>
 				<level compare="at least">1</level>
 			</advantage_prereq>
 			<advantage_prereq has="yes">
-				<name compare="is">quintessence</name>
+				<name compare="is">increased quintessence</name>
 				<notes compare="is anything"></notes>
 				<level compare="at least">1</level>
 			</advantage_prereq>
@@ -4996,12 +4996,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (body control)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -5119,12 +5119,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (fire)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -5209,12 +5209,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (meta)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -5245,12 +5245,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (sound)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -5316,12 +5316,12 @@
 		</categories>
 		<prereq_list all="no">
 			<advantage_prereq has="yes">
-				<name compare="is">quintessence</name>
+				<name compare="is">increased quintessence</name>
 				<notes compare="contains">one college (knowledge)</notes>
 				<level compare="at least">1</level>
 			</advantage_prereq>
 			<advantage_prereq has="yes">
-				<name compare="is">quintessence</name>
+				<name compare="is">increased quintessence</name>
 				<notes compare="is anything"></notes>
 				<level compare="at least">1</level>
 			</advantage_prereq>
@@ -5411,12 +5411,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (making &amp; breaking)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -5574,12 +5574,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (movement)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -5632,12 +5632,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (movement)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -6038,12 +6038,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (enchantment)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -6079,12 +6079,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (meta)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -6450,12 +6450,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (earth)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -6484,12 +6484,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (water)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -6542,12 +6542,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (earth)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -6580,12 +6580,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (knowledge)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -6618,12 +6618,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (mind control)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -6647,12 +6647,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (enchantment)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -6712,12 +6712,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (enchantment)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -6762,12 +6762,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (body control)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -6814,12 +6814,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (body control)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -6921,12 +6921,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (earth)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -6957,12 +6957,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (necromancy)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -7186,12 +7186,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (movement)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="is anything"></notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -7255,12 +7255,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (necromancy)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -7319,12 +7319,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (making &amp; breaking)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -7424,12 +7424,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (making &amp; breaking)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -7485,12 +7485,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (technological)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -7587,12 +7587,12 @@
 		</categories>
 		<prereq_list all="no">
 			<advantage_prereq has="yes">
-				<name compare="is">quintessence</name>
+				<name compare="is">increased quintessence</name>
 				<notes compare="contains">one college (knowledge)</notes>
 				<level compare="at least">1</level>
 			</advantage_prereq>
 			<advantage_prereq has="yes">
-				<name compare="is">quintessence</name>
+				<name compare="is">increased quintessence</name>
 				<notes compare="is anything"></notes>
 				<level compare="at least">1</level>
 			</advantage_prereq>
@@ -7628,12 +7628,12 @@
 			</advantage_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (sound)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -7671,12 +7671,12 @@
 			</prereq_list>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (food)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -7794,12 +7794,12 @@
 			</advantage_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (necromancy)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -7823,12 +7823,12 @@
 		</categories>
 		<prereq_list all="no">
 			<advantage_prereq has="yes">
-				<name compare="is">quintessence</name>
+				<name compare="is">increased quintessence</name>
 				<notes compare="contains">one college (knowledge)</notes>
 				<level compare="at least">1</level>
 			</advantage_prereq>
 			<advantage_prereq has="yes">
-				<name compare="is">quintessence</name>
+				<name compare="is">increased quintessence</name>
 				<notes compare="is anything"></notes>
 				<level compare="at least">1</level>
 			</advantage_prereq>
@@ -7927,12 +7927,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (fire)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -8025,12 +8025,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (fire)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -8084,12 +8084,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (fire)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -8144,12 +8144,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (water)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -8200,12 +8200,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (movement)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -8233,12 +8233,12 @@
 			<prereq_list all="yes">
 				<prereq_list all="no">
 					<advantage_prereq has="yes">
-						<name compare="is">quintessence</name>
+						<name compare="is">increased quintessence</name>
 						<notes compare="contains">one college (movement)</notes>
 						<level compare="at least">2</level>
 					</advantage_prereq>
 					<advantage_prereq has="yes">
-						<name compare="is">quintessence</name>
+						<name compare="is">increased quintessence</name>
 						<notes compare="is anything"></notes>
 						<level compare="at least">2</level>
 					</advantage_prereq>
@@ -8298,12 +8298,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (food)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -8347,12 +8347,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (protection)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -8433,12 +8433,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (mind control)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -8687,12 +8687,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (body control)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -9069,12 +9069,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (mind control)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -9101,12 +9101,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (mind control)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -9134,12 +9134,12 @@
 			<attribute_prereq has="yes" which="iq" compare="at least">12</attribute_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (movement)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -9163,12 +9163,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (healing)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -9206,12 +9206,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (animal)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -9263,12 +9263,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (meta)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -9293,12 +9293,12 @@
 			<attribute_prereq has="yes" which="iq" combined_with="dx" compare="at least">30</attribute_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (enchantment)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -9424,12 +9424,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (healing)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -9587,12 +9587,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (healing)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -9853,12 +9853,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (body control)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -9910,12 +9910,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (enchantment)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -9941,12 +9941,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (body control)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -10131,12 +10131,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (water)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -10214,12 +10214,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (water)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -10421,12 +10421,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (knowledge)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -10653,12 +10653,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (healing)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -10685,12 +10685,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (healing)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -10718,12 +10718,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (healing)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -11033,12 +11033,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (knowledge)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -11116,12 +11116,12 @@
 			</prereq_list>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (knowledge)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -11167,12 +11167,12 @@
 		<prereq_list all="no">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (healing)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -11231,12 +11231,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (technological)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -11289,12 +11289,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (meta)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -11340,12 +11340,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (body control)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -11379,12 +11379,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (mind control)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -11459,12 +11459,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (enchantment)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -11629,12 +11629,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (weather)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -11755,12 +11755,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (weather)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -11884,12 +11884,12 @@
 				</spell_prereq>
 				<prereq_list all="no">
 					<advantage_prereq has="yes">
-						<name compare="is">quintessence</name>
+						<name compare="is">increased quintessence</name>
 						<notes compare="contains">one college (movement)</notes>
 						<level compare="at least">2</level>
 					</advantage_prereq>
 					<advantage_prereq has="yes">
-						<name compare="is">quintessence</name>
+						<name compare="is">increased quintessence</name>
 						<notes compare="is anything"></notes>
 						<level compare="at least">2</level>
 					</advantage_prereq>
@@ -11944,12 +11944,12 @@
 			</prereq_list>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (movement)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -12260,7 +12260,7 @@
 		</categories>
 		<prereq_list all="yes">
 			<advantage_prereq has="yes">
-				<name compare="contains">quintessence</name>
+				<name compare="contains">increased quintessence</name>
 				<notes compare="is anything"></notes>
 				<level compare="at least">1</level>
 			</advantage_prereq>
@@ -12287,12 +12287,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (meta)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -12358,12 +12358,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (healing)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -12419,12 +12419,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (technological)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -12896,12 +12896,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (mind control)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -13144,12 +13144,12 @@
 			</prereq_list>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (protection)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -13227,12 +13227,12 @@
 				</spell_prereq>
 				<prereq_list all="no">
 					<advantage_prereq has="yes">
-						<name compare="is">quintessence</name>
+						<name compare="is">increased quintessence</name>
 						<notes compare="contains">one college (healing)</notes>
 						<level compare="at least">3</level>
 					</advantage_prereq>
 					<advantage_prereq has="yes">
-						<name compare="is">quintessence</name>
+						<name compare="is">increased quintessence</name>
 						<notes compare="is anything"></notes>
 						<level compare="at least">3</level>
 					</advantage_prereq>
@@ -13316,12 +13316,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (mind control)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -13391,12 +13391,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (mind control)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -13505,12 +13505,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (body control)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -13567,12 +13567,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (earth)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -13599,12 +13599,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (animal)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -13657,12 +13657,12 @@
 			<attribute_prereq has="yes" which="iq" compare="at least">12</attribute_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (knowledge)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -13787,12 +13787,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (illusion &amp; creation)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -13840,12 +13840,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (animal)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -13873,12 +13873,12 @@
 			<attribute_prereq has="yes" which="iq" compare="at least">13</attribute_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (mind control)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -13907,12 +13907,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (technological)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -13940,12 +13940,12 @@
 			<attribute_prereq has="yes" which="iq" compare="at least">13</attribute_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (mind control)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -13969,12 +13969,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (communication)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -14004,12 +14004,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (animal)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -14055,12 +14055,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (necromancy)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -14090,12 +14090,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (illusion &amp; creation)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -14154,12 +14154,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (gate)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -14212,12 +14212,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (gate)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -14252,12 +14252,12 @@
 			</prereq_list>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (gate)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -14301,12 +14301,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (gate)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -14359,12 +14359,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (plant)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -14391,12 +14391,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (plant)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -14466,12 +14466,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (plant)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -14627,12 +14627,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (communication)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -14968,12 +14968,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (movement)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -15115,12 +15115,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (movement)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -15278,12 +15278,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (water)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -15314,12 +15314,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (water)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -15356,12 +15356,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (fire)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -15396,12 +15396,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (plant)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -15432,12 +15432,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (earth)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -15473,12 +15473,12 @@
 			</prereq_list>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (gate)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -15551,12 +15551,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (technological)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -15588,12 +15588,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (mind control)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -15618,12 +15618,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (knowledge)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -15654,12 +15654,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (healing)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -15776,12 +15776,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (healing)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -15837,12 +15837,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (plant)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -16033,12 +16033,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (meta)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -16129,12 +16129,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (making &amp; breaking)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -16165,12 +16165,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (movement)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -16376,12 +16376,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (making &amp; breaking)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -16540,12 +16540,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (body control)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -17073,12 +17073,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (making &amp; breaking)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -17148,12 +17148,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (necromancy)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -17211,12 +17211,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (making &amp; breaking)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -17327,12 +17327,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (food)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -17427,12 +17427,12 @@
 			</prereq_list>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (enchantment)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -17484,12 +17484,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (meta)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -17514,12 +17514,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (meta)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -17759,12 +17759,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (gate)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -17945,12 +17945,12 @@
 			<attribute_prereq has="yes" which="iq" compare="at least">12</attribute_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (knowledge)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -18103,12 +18103,12 @@
 			<prereq_list all="yes">
 				<prereq_list all="no">
 					<advantage_prereq has="yes">
-						<name compare="is">quintessence</name>
+						<name compare="is">increased quintessence</name>
 						<notes compare="contains">one college (necromancy)</notes>
 						<level compare="at least">1</level>
 					</advantage_prereq>
 					<advantage_prereq has="yes">
-						<name compare="is">quintessence</name>
+						<name compare="is">increased quintessence</name>
 						<notes compare="is anything"></notes>
 						<level compare="at least">1</level>
 					</advantage_prereq>
@@ -18140,12 +18140,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (body control)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -18312,12 +18312,12 @@
 			</prereq_list>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (technological)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -18373,12 +18373,12 @@
 			</prereq_list>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (technological)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -18423,12 +18423,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (animal)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -18455,12 +18455,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (animal)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -18560,12 +18560,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (making &amp; breaking)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -18613,12 +18613,12 @@
 		</categories>
 		<prereq_list all="no">
 			<advantage_prereq has="yes">
-				<name compare="is">quintessence</name>
+				<name compare="is">increased quintessence</name>
 				<notes compare="contains">one college (protection)</notes>
 				<level compare="at least">2</level>
 			</advantage_prereq>
 			<advantage_prereq has="yes">
-				<name compare="is">quintessence</name>
+				<name compare="is">increased quintessence</name>
 				<notes compare="is anything"></notes>
 				<level compare="at least">2</level>
 			</advantage_prereq>
@@ -18688,12 +18688,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (body control)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -18740,12 +18740,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (body control)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -18865,12 +18865,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (enchantment)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -18971,12 +18971,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (movement)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -19052,12 +19052,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (necromancy)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -19090,12 +19090,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (gate)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -19316,12 +19316,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (necromancy)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -19366,12 +19366,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (enchantment)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -19661,12 +19661,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (meta)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -19772,12 +19772,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (animal)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -19822,12 +19822,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (water)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -19878,12 +19878,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (necromancy)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -19919,12 +19919,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (necromancy)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -19969,12 +19969,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (necromancy)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -20012,12 +20012,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (technological)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -20041,12 +20041,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (necromancy)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -20102,12 +20102,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (necromancy)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -20155,12 +20155,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (necromancy)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -20257,12 +20257,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (earth)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -20393,12 +20393,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (earth)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -20508,12 +20508,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (technological)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -20593,12 +20593,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (mind control)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -20624,12 +20624,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (body control)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -20820,12 +20820,12 @@
 			</prereq_list>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (air)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -20850,12 +20850,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (necromancy)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -20906,12 +20906,12 @@
 			</prereq_list>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (earth)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -20936,12 +20936,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (fire)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -21015,12 +21015,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (necromancy)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -21068,12 +21068,12 @@
 			</prereq_list>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (water)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -21138,12 +21138,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (light)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -21177,12 +21177,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (meta)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -21233,12 +21233,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (meta)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -21314,12 +21314,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (meta)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -21346,12 +21346,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (gate)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -21501,12 +21501,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (meta)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -21578,12 +21578,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (movement)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -21782,12 +21782,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (body control)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -21916,12 +21916,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (gate)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -21951,12 +21951,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (gate)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -22206,12 +22206,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (making &amp; breaking)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -22260,12 +22260,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (body control)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -22465,12 +22465,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (protection)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -22545,12 +22545,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (mind control)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -22733,12 +22733,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (water)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -22892,12 +22892,12 @@
 		</categories>
 		<prereq_list all="no">
 			<advantage_prereq has="yes">
-				<name compare="is">quintessence</name>
+				<name compare="is">increased quintessence</name>
 				<notes compare="contains">one college (meta)</notes>
 				<level compare="at least">1</level>
 			</advantage_prereq>
 			<advantage_prereq has="yes">
-				<name compare="is">quintessence</name>
+				<name compare="is">increased quintessence</name>
 				<notes compare="is anything"></notes>
 				<level compare="at least">1</level>
 			</advantage_prereq>
@@ -23151,12 +23151,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (mind control)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -23191,12 +23191,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (making &amp; breaking)</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">2</level>
 				</advantage_prereq>
@@ -23470,12 +23470,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (body control)</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">1</level>
 				</advantage_prereq>
@@ -23662,12 +23662,12 @@
 			</spell_prereq>
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (enchantment)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
@@ -23692,12 +23692,12 @@
 		<prereq_list all="yes">
 			<prereq_list all="no">
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="contains">one college (healing)</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>
 				<advantage_prereq has="yes">
-					<name compare="is">quintessence</name>
+					<name compare="is">increased quintessence</name>
 					<notes compare="does not contain">one college</notes>
 					<level compare="at least">3</level>
 				</advantage_prereq>


### PR DESCRIPTION
Noticed these a while ago but finally got around to fixing it.
Obsession has a self control roll and is a mental disadvantage, not physical.
Gear related perks from PU Advantage library had nonsensical prerequisites.
Of course there's a lot of meaningless changes in Power Ups Advantages thanks to the reordering.